### PR TITLE
Add generator module for protoc plugin development

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -57,7 +57,7 @@ make generate
 This project uses the same build system as other protomcp.org repositories:
 
 - **Module**: `protomcp.org/common`
-- **No submodules**: Single module structure for simplicity
+- **Submodules**: Organized as Go submodules (generator, with more to follow)
 - **Shared tooling**: Same linting and quality tools as siblings
 
 ### Tool Integration
@@ -97,16 +97,25 @@ Tool configurations are stored in `internal/build/`:
 
 ### Core Components
 
-- **Common utilities**: General-purpose helper functions
-- **Test utilities**: Shared testing helpers and assertions
-- **Error patterns**: Consistent error handling across projects
+- **Common utilities**: General-purpose helper functions.
+- **Test utilities**: Shared testing helpers and assertions.
+- **Error patterns**: Consistent error handling across projects.
+- **Generator submodule**: Common utilities for `protoc` plugin development.
 
 ### Key Features
 
-- **Minimal dependencies**: Keep external dependencies to a minimum
-- **Interface-based**: Prefer interfaces for flexibility
-- **Well-tested**: High test coverage for reliability
-- **Documentation**: All public APIs must be documented
+- **Minimal dependencies**: Keep external dependencies to a minimum.
+- **Interface-based**: Prefer interfaces for flexibility.
+- **Well-tested**: High test coverage for reliability.
+- **Documentation**: All public APIs must be documented.
+
+### Submodules
+
+- **generator/**: Utilities for `protoc` plugin development
+  - Descriptor traversal and type checking.
+  - Path construction and naming utilities.
+  - Visitor patterns for walking descriptor trees.
+  - Code generation helpers.
 
 ## Development Workflow
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Common
 
 [![Go Reference][godoc-badge]][godoc-link]
+[![Go Report Card][goreportcard-badge]][goreportcard-link]
 [![codecov][codecov-badge]][codecov-link]
 
 Common provides shared utilities for protomcp.org projects.
@@ -11,12 +12,26 @@ The `common` package serves as a foundation for other protomcp.org repositories,
 providing reusable components for error handling and general utilities that are
 shared between `nanorpc`, `protomcp`, and related projects.
 
+## Submodules
+
+### Generator
+
+The `generator` submodule provides utilities for `protoc` plugin development:
+
+- **Location**: `./generator`
+- **Import**: `import "protomcp.org/common/generator"`
+- **Purpose**: Common helpers for building protocol buffer code generators.
+
+See [generator/README.md](generator/README.md) for detailed documentation.
+
 ## Features
 
 - **Shared Types**: Reusable data structures and interfaces
 - **Error Handling**: Consistent error patterns across projects
 - **Utility Functions**: General-purpose helper functions like slice tools
 - **Testing Support**: Integrates with `darvaza.org/core` for test utilities
+- **Generator Utilities**: Common helpers for `protoc` plugin development in the
+  `generator` submodule
 
 ## Slice Utilities
 
@@ -214,5 +229,7 @@ See [LICENCE.txt](LICENCE.txt) for licensing information.
 
 [godoc-badge]: https://pkg.go.dev/badge/protomcp.org/common.svg
 [godoc-link]: https://pkg.go.dev/protomcp.org/common
+[goreportcard-badge]: https://goreportcard.com/badge/protomcp.org/common
+[goreportcard-link]: https://goreportcard.com/report/protomcp.org/common
 [codecov-badge]: https://codecov.io/gh/protomcp/common/graph/badge.svg
 [codecov-link]: https://codecov.io/gh/protomcp/common

--- a/generator/LICENCE.txt
+++ b/generator/LICENCE.txt
@@ -1,0 +1,19 @@
+Copyright 2025 Apptly Software Ltd <oss@apptly.co>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/generator/README.md
+++ b/generator/README.md
@@ -1,0 +1,232 @@
+# Generator Module (PLACEHOLDER)
+
+[![Go Reference][godoc-badge]][godoc-link]
+[![Go Report Card][goreportcard-badge]][goreportcard-link]
+[![codecov][codecov-badge]][codecov-link]
+
+> [!WARNING]
+> **PLACEHOLDER MODULE - NOT YET IMPLEMENTED**
+>
+> This module is a placeholder showing the planned architecture for common
+> utilities for protoc plugin code generators. It will provide helpers for
+> working with protocol buffer descriptors, managing code generation, and
+> traversing descriptor trees.
+
+## Overview
+
+**PLANNED FUNCTIONALITY (NOT YET AVAILABLE):**
+
+The generator module will provide essential utilities that all protoc plugins
+need when generating code from protocol buffer descriptors. It will serve as a
+foundation for building robust code generators with consistent patterns.
+
+## Core Utilities
+
+### Descriptor Type Checking
+
+Essential for the options module and other generators:
+
+```go
+// Type checking - needed by options for conditional logic
+func IsMessageType(desc proto.Message, name string) bool
+func IsFieldType(desc proto.Message) bool
+func IsServiceType(desc proto.Message) bool
+func IsMethodType(desc proto.Message) bool
+func IsEnumType(desc proto.Message) bool
+func IsFileType(desc proto.Message) bool
+
+// Specific type checks
+func IsRepeatedField(field proto.Message) bool
+func IsMapField(field proto.Message) bool
+func IsOneofField(field proto.Message) bool
+func IsOptionalField(field proto.Message) bool
+func IsRequiredField(field proto.Message) bool
+```
+
+### Path and Naming Utilities
+
+Required by options module for selector matching:
+
+```go
+// Path construction - needed for option selectors
+func GetMessageName(desc proto.Message) string
+func GetFieldPath(file, msg, field proto.Message) string
+func GetFullName(desc proto.Message) string
+func GetPackage(file proto.Message) string
+func GetQualifiedName(desc proto.Message) string
+
+// Name manipulation
+func ToGoName(name string) string
+func ToCamelCase(name string) string
+func ToSnakeCase(name string) string
+func ToKebabCase(name string) string
+```
+
+### Descriptor Traversal
+
+Critical for options module's hook system:
+
+```go
+// Finding descriptors - needed for option resolution
+func FindMessage(file proto.Message, name string) proto.Message
+func FindField(msg proto.Message, name string) proto.Message
+func FindEnum(file proto.Message, name string) proto.Message
+func FindService(file proto.Message, name string) proto.Message
+func FindMethod(service proto.Message, name string) proto.Message
+
+// Iteration helpers - needed for applying option hooks
+// Callback returns true to continue, false to stop (Go 1.23 convention)
+func ForEachField(msg proto.Message, fn func(field proto.Message) bool) error
+func ForEachMessage(file proto.Message, fn func(msg proto.Message) bool) error
+func ForEachEnum(file proto.Message, fn func(enum proto.Message) bool) error
+func ForEachService(file proto.Message, fn func(svc proto.Message) bool) error
+func ForEachMethod(svc proto.Message, fn func(method proto.Message) bool) error
+
+// Nested traversal
+func ForEachNestedMessage(
+    msg proto.Message, fn func(nested proto.Message) bool) error
+func ForEachNestedEnum(
+    msg proto.Message, fn func(enum proto.Message) bool) error
+```
+
+### Tree Walking
+
+Simple functions for walking descriptor trees:
+
+```go
+// Walk descriptor tree with callback functions
+func Walk(file proto.Message, onMessage func(proto.Message) error) error
+func WalkMessage(msg proto.Message, onField func(proto.Message) error) error
+
+// Path-aware walking
+func WalkWithPath(file proto.Message,
+    callback func(path []string, desc proto.Message) error) error
+```
+
+### Type Resolution
+
+Needed by options for type-safe option handling:
+
+```go
+// Type information
+func GetFieldType(field proto.Message) descriptorpb.FieldDescriptorProto_Type
+func GetFieldTypeName(field proto.Message) string
+func IsScalarType(field proto.Message) bool
+func IsMessageType(field proto.Message) bool
+func IsEnumType(field proto.Message) bool
+
+// Type lookup
+func ResolveTypeName(file proto.Message, typeName string) proto.Message
+func GetTypeDescriptor(field proto.Message) proto.Message
+```
+
+### Dependency Analysis
+
+Useful for both options and code generation:
+
+```go
+// Dependency tracking
+func GetFileDependencies(file proto.Message) []string
+func GetMessageDependencies(msg proto.Message) []string
+func GetFieldDependencies(field proto.Message) []string
+
+// Import management
+func GetRequiredImports(file proto.Message) []string
+func ResolveImportPath(file proto.Message, typeName string) string
+```
+
+## Comment Access
+
+Helper functions for reading comments from descriptors:
+
+```go
+// Comment reading
+func GetLeadingComments(desc proto.Message) string
+func GetTrailingComments(desc proto.Message) string
+```
+
+## Integration with Options Module
+
+The options module relies heavily on these utilities:
+
+1. **Type Checking**: For conditional option application
+2. **Path Building**: For selector matching
+3. **Traversal**: For applying hooks to matching elements
+4. **Context**: Shared context for environment-aware options
+
+Example usage in options module:
+
+```go
+// options module using generator utilities
+func (r *Registry) applyHooks(file proto.Message) error {
+    var hookErr error
+
+    err := generator.ForEachMessage(file, func(msg proto.Message) bool {
+        // Apply hooks to this message and its fields
+        hookErr = r.applyMessageHooks(file, msg)
+        return hookErr == nil // continue if no error
+    })
+
+    if hookErr != nil {
+        return hookErr
+    }
+    return err
+}
+
+func (r *Registry) applyMessageHooks(file, msg proto.Message) error {
+    msgPath := generator.GetFullName(msg)
+
+    // Apply hook to message itself if it matches
+    if MatchesSelector(r.selector, msgPath) {
+        if err := r.runHooks(msg, r.GetMessageOptions(file, msg)); err != nil {
+            return err
+        }
+    }
+
+    // Apply hooks to each field
+    var fieldErr error
+    err := generator.ForEachField(msg, func(field proto.Message) bool {
+        fieldPath := generator.GetFieldPath(file, msg, field)
+        if MatchesSelector(r.selector, fieldPath) {
+            opts := r.GetFieldOptions(file, msg, field)
+            fieldErr = r.runHooks(field, opts)
+            return fieldErr == nil // continue if no error
+        }
+        return true // continue to next field
+    })
+
+    if fieldErr != nil {
+        return fieldErr
+    }
+    return err
+}
+```
+
+## Best Practices
+
+1. **Nil Safety**: All functions handle nil inputs gracefully.
+2. **Error Propagation**: Iteration functions stop on first error.
+3. **Type Safety**: Use type assertions with checks for proto.Message types.
+4. **Performance**: Cache frequently accessed paths and names.
+5. **Compatibility**: Support both proto2 and proto3 descriptors.
+
+## Future Extensions
+
+- Additional traversal helpers.
+- Dependency graph visualization.
+- Performance optimizations for large schemas.
+- Parallel traversal support.
+
+---
+
+**NOTE:** This entire module is currently a placeholder demonstrating the
+intended architecture and planned features. Actual implementation will be added
+in future releases as the protomcp.org ecosystem develops and the need for
+these utilities becomes concrete.
+
+[godoc-badge]: https://pkg.go.dev/badge/protomcp.org/common/generator.svg
+[godoc-link]: https://pkg.go.dev/protomcp.org/common/generator
+[goreportcard-badge]: https://goreportcard.com/badge/protomcp.org/common
+[goreportcard-link]: https://goreportcard.com/report/protomcp.org/common
+[codecov-badge]: https://codecov.io/gh/protomcp/common/graph/badge.svg?flag=generator
+[codecov-link]: https://codecov.io/gh/protomcp/common?flag=generator

--- a/generator/README.md
+++ b/generator/README.md
@@ -1,26 +1,130 @@
-# Generator Module (PLACEHOLDER)
+# Generator Module
 
 [![Go Reference][godoc-badge]][godoc-link]
 [![Go Report Card][goreportcard-badge]][goreportcard-link]
 [![codecov][codecov-badge]][codecov-link]
 
-> [!WARNING]
-> **PLACEHOLDER MODULE - NOT YET IMPLEMENTED**
->
-> This module is a placeholder showing the planned architecture for common
-> utilities for protoc plugin code generators. It will provide helpers for
-> working with protocol buffer descriptors, managing code generation, and
-> traversing descriptor trees.
-
 ## Overview
 
-**PLANNED FUNCTIONALITY (NOT YET AVAILABLE):**
+The generator module provides utilities for protoc plugin development, starting
+with test utilities for creating descriptor objects in tests.
 
-The generator module will provide essential utilities that all protoc plugins
-need when generating code from protocol buffer descriptors. It will serve as a
-foundation for building robust code generators with consistent patterns.
+## Test Utilities
 
-## Core Utilities
+Helper functions for creating descriptor objects in tests:
+
+### Field Creation Functions
+
+Complete field constructors (with name and number):
+
+| Function | Purpose | Parameters | Returns |
+|----------|---------|------------|---------|
+| `NewField` | Create optional field | `name string, number int32, fieldType descriptorpb.FieldDescriptorProto_Type` | `*descriptorpb.FieldDescriptorProto` |
+| `NewRepeatedField` | Create repeated field | `name string, number int32, fieldType descriptorpb.FieldDescriptorProto_Type` | `*descriptorpb.FieldDescriptorProto` |
+| `NewRequiredField` | Create required field (proto2) | `name string, number int32, fieldType descriptorpb.FieldDescriptorProto_Type` | `*descriptorpb.FieldDescriptorProto` |
+| `NewMessageField` | Create message type field | `name string, number int32, typeName string` | `*descriptorpb.FieldDescriptorProto` |
+| `NewEnumField` | Create enum type field | `name string, number int32, typeName string` | `*descriptorpb.FieldDescriptorProto` |
+| `NewMapField` | Create map field | `name string, number int32, entryTypeName string` | `*descriptorpb.FieldDescriptorProto` |
+| `NewOneOfField` | Create oneof field | `name string, number int32, fieldType descriptorpb.FieldDescriptorProto_Type, oneofIndex int32` | `*descriptorpb.FieldDescriptorProto` |
+
+Minimal field constructors (for testing specific properties):
+
+| Function | Purpose | Parameters | Returns |
+|----------|---------|------------|---------|
+| `NewFieldWithType` | Create field with type only | `fieldType descriptorpb.FieldDescriptorProto_Type` | `*descriptorpb.FieldDescriptorProto` |
+| `NewFieldWithLabel` | Create field with label only | `label descriptorpb.FieldDescriptorProto_Label` | `*descriptorpb.FieldDescriptorProto` |
+| `NewRepeatedMessageField` | Create repeated message field | `typeName string` | `*descriptorpb.FieldDescriptorProto` |
+
+### Descriptor Creation Functions
+
+| Function | Purpose | Parameters | Returns |
+|----------|---------|------------|---------|
+| `NewMessage` | Create message descriptor | `name string, fields ...*descriptorpb.FieldDescriptorProto` | `*descriptorpb.DescriptorProto` |
+| `NewMessageWithNested` | Create message with nested types | `name string, messages []*descriptorpb.DescriptorProto, enums []*descriptorpb.EnumDescriptorProto` | `*descriptorpb.DescriptorProto` |
+| `NewEnum` | Create enum descriptor | `name string, values ...string` | `*descriptorpb.EnumDescriptorProto` |
+| `NewEnumValue` | Create enum value descriptor | `name string, number int32` | `*descriptorpb.EnumValueDescriptorProto` |
+| `NewService` | Create service descriptor | `name string, methods ...*descriptorpb.MethodDescriptorProto` | `*descriptorpb.ServiceDescriptorProto` |
+| `NewMethod` | Create method descriptor | `name, inputType, outputType string` | `*descriptorpb.MethodDescriptorProto` |
+| `NewFile` | Create file descriptor | `name, pkg string, messages []*descriptorpb.DescriptorProto` | `*descriptorpb.FileDescriptorProto` |
+| `NewFileWithTypes` | Create file with types | `name, pkg string, messages []*descriptorpb.DescriptorProto, enums []*descriptorpb.EnumDescriptorProto, services []*descriptorpb.ServiceDescriptorProto` | `*descriptorpb.FileDescriptorProto` |
+| `NewOneOf` | Create oneof descriptor | `name string` | `*descriptorpb.OneofDescriptorProto` |
+
+### Type Constants
+
+<!-- cspell:ignore SINT SFIXED -->
+
+| Constant | Type | Value |
+|----------|------|-------|
+| `TypeDouble` | Floating point | `descriptorpb.FieldDescriptorProto_TYPE_DOUBLE` |
+| `TypeFloat` | Floating point | `descriptorpb.FieldDescriptorProto_TYPE_FLOAT` |
+| `TypeInt64` | Signed integer | `descriptorpb.FieldDescriptorProto_TYPE_INT64` |
+| `TypeUInt64` | Unsigned integer | `descriptorpb.FieldDescriptorProto_TYPE_UINT64` |
+| `TypeInt32` | Signed integer | `descriptorpb.FieldDescriptorProto_TYPE_INT32` |
+| `TypeFixed64` | Fixed size | `descriptorpb.FieldDescriptorProto_TYPE_FIXED64` |
+| `TypeFixed32` | Fixed size | `descriptorpb.FieldDescriptorProto_TYPE_FIXED32` |
+| `TypeBool` | Boolean | `descriptorpb.FieldDescriptorProto_TYPE_BOOL` |
+| `TypeString` | String | `descriptorpb.FieldDescriptorProto_TYPE_STRING` |
+| `TypeBytes` | Binary | `descriptorpb.FieldDescriptorProto_TYPE_BYTES` |
+| `TypeUInt32` | Unsigned integer | `descriptorpb.FieldDescriptorProto_TYPE_UINT32` |
+| `TypeSFixed32` | Signed fixed | `descriptorpb.FieldDescriptorProto_TYPE_SFIXED32` |
+| `TypeSFixed64` | Signed fixed | `descriptorpb.FieldDescriptorProto_TYPE_SFIXED64` |
+| `TypeSInt32` | Signed integer | `descriptorpb.FieldDescriptorProto_TYPE_SINT32` |
+| `TypeSInt64` | Signed integer | `descriptorpb.FieldDescriptorProto_TYPE_SINT64` |
+| `TypeGroup` | Group (deprecated) | `descriptorpb.FieldDescriptorProto_TYPE_GROUP` |
+| `TypeMessage` | Message | `descriptorpb.FieldDescriptorProto_TYPE_MESSAGE` |
+| `TypeEnum` | Enum | `descriptorpb.FieldDescriptorProto_TYPE_ENUM` |
+
+### Example Usage
+
+```go
+import (
+    "testing"
+
+    "darvaza.org/core"
+    "google.golang.org/protobuf/proto"
+    "google.golang.org/protobuf/types/descriptorpb"
+    "protomcp.org/common/generator"
+)
+
+func TestMyGenerator(t *testing.T) {
+    // Creating complete message descriptors for testing
+    msg := &descriptorpb.DescriptorProto{
+        Name: proto.String("User"),
+        Field: []*descriptorpb.FieldDescriptorProto{
+            generator.NewField("id", 1, generator.TypeInt64),
+            generator.NewRepeatedField("tags", 2, generator.TypeString),
+            generator.NewMessageField("profile", 3, ".example.Profile"),
+            generator.NewEnumField("status", 4, ".example.Status"),
+            generator.NewMapField("metadata", 5, ".MetadataEntry"),
+            generator.NewOneOfField("variant", 6, generator.TypeBool, 0),
+        },
+    }
+    // Test generator with the constructed message
+    core.AssertNotNil(t, msg, "message")
+    core.AssertEqual(t, "User", msg.GetName(), "message name")
+}
+
+// Minimal field descriptors for testing specific behaviour
+func TestFieldProperties(t *testing.T) {
+    // Create fields with only the properties needed for testing
+    messageField := generator.NewFieldWithType(generator.TypeMessage)
+    repeatedField := generator.NewFieldWithLabel(
+        descriptorpb.FieldDescriptorProto_LABEL_REPEATED)
+    mapField := generator.NewRepeatedMessageField(".MapEntry")
+
+    // Test field properties using core assertions
+    core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_MESSAGE,
+        messageField.GetType(), "field type")
+    core.AssertEqual(t, descriptorpb.FieldDescriptorProto_LABEL_REPEATED,
+        repeatedField.GetLabel(), "field label")
+    core.AssertNotNil(t, mapField.TypeName, "map field type name")
+}
+```
+
+## Planned Core Functionality
+
+The following sections describe planned functionality that will be added
+incrementally as the protomcp.org ecosystem develops.
 
 ### Descriptor Type Checking
 
@@ -145,63 +249,6 @@ func GetLeadingComments(desc proto.Message) string
 func GetTrailingComments(desc proto.Message) string
 ```
 
-## Integration with Options Module
-
-The options module relies heavily on these utilities:
-
-1. **Type Checking**: For conditional option application
-2. **Path Building**: For selector matching
-3. **Traversal**: For applying hooks to matching elements
-4. **Context**: Shared context for environment-aware options
-
-Example usage in options module:
-
-```go
-// options module using generator utilities
-func (r *Registry) applyHooks(file proto.Message) error {
-    var hookErr error
-
-    err := generator.ForEachMessage(file, func(msg proto.Message) bool {
-        // Apply hooks to this message and its fields
-        hookErr = r.applyMessageHooks(file, msg)
-        return hookErr == nil // continue if no error
-    })
-
-    if hookErr != nil {
-        return hookErr
-    }
-    return err
-}
-
-func (r *Registry) applyMessageHooks(file, msg proto.Message) error {
-    msgPath := generator.GetFullName(msg)
-
-    // Apply hook to message itself if it matches
-    if MatchesSelector(r.selector, msgPath) {
-        if err := r.runHooks(msg, r.GetMessageOptions(file, msg)); err != nil {
-            return err
-        }
-    }
-
-    // Apply hooks to each field
-    var fieldErr error
-    err := generator.ForEachField(msg, func(field proto.Message) bool {
-        fieldPath := generator.GetFieldPath(file, msg, field)
-        if MatchesSelector(r.selector, fieldPath) {
-            opts := r.GetFieldOptions(file, msg, field)
-            fieldErr = r.runHooks(field, opts)
-            return fieldErr == nil // continue if no error
-        }
-        return true // continue to next field
-    })
-
-    if fieldErr != nil {
-        return fieldErr
-    }
-    return err
-}
-```
-
 ## Best Practices
 
 1. **Nil Safety**: All functions handle nil inputs gracefully.
@@ -216,13 +263,6 @@ func (r *Registry) applyMessageHooks(file, msg proto.Message) error {
 - Dependency graph visualization.
 - Performance optimizations for large schemas.
 - Parallel traversal support.
-
----
-
-**NOTE:** This entire module is currently a placeholder demonstrating the
-intended architecture and planned features. Actual implementation will be added
-in future releases as the protomcp.org ecosystem develops and the need for
-these utilities becomes concrete.
 
 [godoc-badge]: https://pkg.go.dev/badge/protomcp.org/common/generator.svg
 [godoc-link]: https://pkg.go.dev/protomcp.org/common/generator

--- a/generator/descriptor.go
+++ b/generator/descriptor.go
@@ -1,0 +1,413 @@
+package generator
+
+import (
+	"strings"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+// AsMessage attempts to cast the descriptor to a message descriptor and validates it has a Name.
+// Returns the message descriptor and true if successful and Name is not nil/empty, nil and false otherwise.
+// A DescriptorProto without a Name is considered invalid as every message must have a name.
+func AsMessage(desc proto.Message) (*descriptorpb.DescriptorProto, bool) {
+	msgDesc, ok := desc.(*descriptorpb.DescriptorProto)
+	if ok && isPointerNonZero(msgDesc.Name) {
+		return msgDesc, true
+	}
+	return nil, false
+}
+
+// IsMessage checks if the descriptor is a message descriptor.
+// Returns true if the descriptor is a DescriptorProto, false otherwise.
+func IsMessage(desc proto.Message) bool {
+	_, ok := AsMessage(desc)
+	return ok
+}
+
+// AsMessageWithName attempts to cast the descriptor to a message descriptor and checks if it has the given name.
+// Returns the message descriptor and true if successful and name matches (empty name matches any).
+func AsMessageWithName(desc proto.Message, name string) (*descriptorpb.DescriptorProto, bool) {
+	msgDesc, ok := AsMessage(desc)
+	switch {
+	case !ok:
+		// Wrong type
+		return nil, false
+	case name == "", isPointerEqual(msgDesc.Name, name):
+		// Match or any accepted
+		return msgDesc, true
+	default:
+		// Name doesn't match
+		return nil, false
+	}
+}
+
+// IsMessageWithName checks if the descriptor is a message type with the given name.
+// Returns true if the descriptor is a DescriptorProto with matching name, false otherwise.
+func IsMessageWithName(desc proto.Message, name string) bool {
+	_, ok := AsMessageWithName(desc, name)
+	return ok
+}
+
+// AsFieldType attempts to cast the descriptor to a field descriptor and validates it has a Type.
+// Returns the field descriptor and true if successful and Type is not nil, nil and false otherwise.
+// A FieldDescriptorProto without a Type is considered invalid as every field must have a type.
+func AsFieldType(desc proto.Message) (*descriptorpb.FieldDescriptorProto, bool) {
+	fieldDesc, ok := desc.(*descriptorpb.FieldDescriptorProto)
+	if ok && fieldDesc.Type != nil {
+		return fieldDesc, true
+	}
+	return nil, false
+}
+
+// IsFieldType checks if the descriptor is a valid field descriptor.
+// Returns true if the descriptor is a FieldDescriptorProto with Type set, false otherwise.
+func IsFieldType(desc proto.Message) bool {
+	_, ok := AsFieldType(desc)
+	return ok
+}
+
+// AsServiceType attempts to cast the descriptor to a service descriptor and validates it has a Name.
+// Returns the service descriptor and true if successful and Name is not nil/empty, nil and false otherwise.
+// A ServiceDescriptorProto without a Name is considered invalid as every service must have a name.
+func AsServiceType(desc proto.Message) (*descriptorpb.ServiceDescriptorProto, bool) {
+	svcDesc, ok := desc.(*descriptorpb.ServiceDescriptorProto)
+	if ok && isPointerNonZero(svcDesc.Name) {
+		return svcDesc, true
+	}
+	return nil, false
+}
+
+// IsServiceType checks if the descriptor is a service descriptor.
+// Returns true if the descriptor is a ServiceDescriptorProto, false otherwise.
+func IsServiceType(desc proto.Message) bool {
+	_, ok := AsServiceType(desc)
+	return ok
+}
+
+// AsMethodType attempts to cast the descriptor to a method descriptor and validates essential fields.
+// Returns the method descriptor and true if successful with valid Name, InputType and OutputType.
+// A MethodDescriptorProto without these fields is considered invalid.
+func AsMethodType(desc proto.Message) (*descriptorpb.MethodDescriptorProto, bool) {
+	methodDesc, ok := desc.(*descriptorpb.MethodDescriptorProto)
+	switch {
+	case !ok:
+		return nil, false
+	case !isPointerNonZero(methodDesc.Name):
+		return nil, false
+	case !isPointerNonZero(methodDesc.InputType):
+		return nil, false
+	case !isPointerNonZero(methodDesc.OutputType):
+		return nil, false
+	default:
+		return methodDesc, true
+	}
+}
+
+// IsMethodType checks if the descriptor is a method descriptor.
+// Returns true if the descriptor is a MethodDescriptorProto, false otherwise.
+func IsMethodType(desc proto.Message) bool {
+	_, ok := AsMethodType(desc)
+	return ok
+}
+
+// AsEnumType attempts to cast the descriptor to an enum descriptor and validates it has a Name.
+// Returns the enum descriptor and true if successful and Name is not nil/empty, nil and false otherwise.
+// An EnumDescriptorProto without a Name is considered invalid as every enum must have a name.
+func AsEnumType(desc proto.Message) (*descriptorpb.EnumDescriptorProto, bool) {
+	enumDesc, ok := desc.(*descriptorpb.EnumDescriptorProto)
+	if ok && isPointerNonZero(enumDesc.Name) {
+		return enumDesc, true
+	}
+	return nil, false
+}
+
+// IsEnumType checks if the descriptor is an enum descriptor.
+// Returns true if the descriptor is an EnumDescriptorProto, false otherwise.
+func IsEnumType(desc proto.Message) bool {
+	_, ok := AsEnumType(desc)
+	return ok
+}
+
+// AsFileType attempts to cast the descriptor to a file descriptor and validates it has a Name.
+// Returns the file descriptor and true if successful and Name is not nil/empty, nil and false otherwise.
+// A FileDescriptorProto without a Name is considered invalid as every file must have a name.
+func AsFileType(desc proto.Message) (*descriptorpb.FileDescriptorProto, bool) {
+	fileDesc, ok := desc.(*descriptorpb.FileDescriptorProto)
+	if ok && isPointerNonZero(fileDesc.Name) {
+		return fileDesc, true
+	}
+	return nil, false
+}
+
+// IsFileType checks if the descriptor is a file descriptor.
+// Returns true if the descriptor is a FileDescriptorProto, false otherwise.
+func IsFileType(desc proto.Message) bool {
+	_, ok := AsFileType(desc)
+	return ok
+}
+
+// AsRepeatedField checks if the field is repeated and returns it as a field descriptor.
+// Returns the field descriptor and true if it's a repeated field, nil and false otherwise.
+func AsRepeatedField(field proto.Message) (*descriptorpb.FieldDescriptorProto, bool) {
+	fieldDesc, ok := AsFieldType(field)
+	switch {
+	case !ok:
+		// Wrong type
+		return nil, false
+	case !isPointerEqual(fieldDesc.Label, LabelRepeated):
+		// Missing label or not repeated
+		return nil, false
+	default:
+		// Is repeated
+		return fieldDesc, true
+	}
+}
+
+// IsRepeatedField checks if the field is repeated.
+// Returns true if the field has LABEL_REPEATED, false otherwise.
+func IsRepeatedField(field proto.Message) bool {
+	_, ok := AsRepeatedField(field)
+	return ok
+}
+
+// AsMapField checks if the field is a map field and returns it as a field descriptor.
+// In protobuf, map fields are represented as repeated message fields
+// where the message type is a special map entry type.
+// This function uses a heuristic: type names ending with "Entry".
+// For definitive checking, use AsMapFieldWithMessage.
+// Returns the field descriptor and true if it's a map field, nil and false otherwise.
+func AsMapField(field proto.Message) (*descriptorpb.FieldDescriptorProto, bool) {
+	// Must be a repeated message field
+	fieldDesc, ok := AsRepeatedField(field)
+	switch {
+	case !ok:
+		return nil, false
+	case !isPointerEqual(fieldDesc.Type, TypeMessage):
+		return nil, false
+	case !isPointerNonZero(fieldDesc.TypeName):
+		return nil, false
+	case !strings.HasSuffix(*fieldDesc.TypeName, "Entry"):
+		return nil, false
+	default:
+		// Check if the type name indicates a map entry.
+		// This is a heuristic - map entry messages typically end with "Entry".
+		// This is not definitive - false positives/negatives are possible.
+		return fieldDesc, true
+	}
+}
+
+// AsMapFieldWithMessage checks if the field is a map field by examining the map entry's message descriptor.
+// This is the definitive check as it verifies the map_entry=true option.
+// Returns the field descriptor and true if it's a map field, nil and false otherwise.
+func AsMapFieldWithMessage(field proto.Message, entryMsg proto.Message) (*descriptorpb.FieldDescriptorProto, bool) {
+	fieldDesc, ok := AsMapField(field)
+	switch {
+	case !ok:
+		// Not a map field according to heuristic
+		return nil, false
+	case entryMsg == nil:
+		// no message to validate against, accept
+		return fieldDesc, true
+	}
+
+	// Check for map_entry option in the message descriptor
+	msg, ok := AsMessage(entryMsg)
+	switch {
+	case !ok, msg.Options == nil, !isPointerNonZero(msg.Options.MapEntry):
+		return nil, false
+	default:
+		return fieldDesc, true
+	}
+}
+
+// IsMapField checks if the field is a map field.
+// Returns true if the field represents a protobuf map, false otherwise.
+func IsMapField(field proto.Message) bool {
+	_, ok := AsMapField(field)
+	return ok
+}
+
+// IsMapFieldWithMessage checks if the field is a map field with definitive message descriptor check.
+// Returns true if the field represents a protobuf map with map_entry=true, false otherwise.
+func IsMapFieldWithMessage(field proto.Message, entryMsg proto.Message) bool {
+	_, ok := AsMapFieldWithMessage(field, entryMsg)
+	return ok
+}
+
+// AsOneOfField checks if the field is part of a oneof and returns it as a field descriptor.
+// Returns the field descriptor and true if it's part of a oneof, nil and false otherwise.
+func AsOneOfField(field proto.Message) (*descriptorpb.FieldDescriptorProto, bool) {
+	fieldDesc, ok := AsFieldType(field)
+	switch {
+	case !ok:
+		return nil, false
+	case fieldDesc.OneofIndex == nil:
+		// A field is part of a oneof if it has a OneofIndex set
+		return nil, false
+	default:
+		return fieldDesc, true
+	}
+}
+
+// IsOneOfField checks if the field is part of a oneof.
+// Returns true if the field has a OneofIndex set, false otherwise.
+func IsOneOfField(field proto.Message) bool {
+	_, ok := AsOneOfField(field)
+	return ok
+}
+
+// AsOptionalField checks if the field is optional and returns it as a field descriptor.
+// Returns the field descriptor and true if it has LABEL_OPTIONAL, nil and false otherwise.
+//
+// Note: This returns true for all fields with LABEL_OPTIONAL, which includes:
+//   - Proto2 optional fields
+//   - Proto3 optional fields (with 'optional' keyword, also have Proto3Optional=true)
+//   - Proto3 singular fields (without 'optional' keyword, have Proto3Optional=false/nil)
+//
+// To distinguish proto3 'optional' fields specifically, check the Proto3Optional field.
+func AsOptionalField(field proto.Message) (*descriptorpb.FieldDescriptorProto, bool) {
+	fieldDesc, ok := AsFieldType(field)
+	switch {
+	case !ok:
+		// Wrong type
+		return nil, false
+	case !isPointerEqual(fieldDesc.Label, LabelOptional):
+		// Missing label or not optional
+		return nil, false
+	default:
+		// Is optional
+		return fieldDesc, true
+	}
+}
+
+// IsOptionalField checks if the field is optional.
+// Returns true if the field has LABEL_OPTIONAL, false otherwise.
+//
+// Note: This returns true for all fields with LABEL_OPTIONAL, which includes:
+//   - Proto2 optional fields
+//   - Proto3 optional fields (with 'optional' keyword, also have Proto3Optional=true)
+//   - Proto3 singular fields (without 'optional' keyword, have Proto3Optional=false/nil)
+//
+// To distinguish proto3 'optional' fields specifically, check the Proto3Optional field.
+func IsOptionalField(field proto.Message) bool {
+	_, ok := AsOptionalField(field)
+	return ok
+}
+
+// AsRequiredField checks if the field is required and returns it as a field descriptor.
+// Returns the field descriptor and true if it's required, nil and false otherwise (proto2 only).
+func AsRequiredField(field proto.Message) (*descriptorpb.FieldDescriptorProto, bool) {
+	fieldDesc, ok := AsFieldType(field)
+	switch {
+	case !ok:
+		// Wrong type
+		return nil, false
+	case !isPointerEqual(fieldDesc.Label, LabelRequired):
+		// Missing label or not required
+		return nil, false
+	default:
+		// Is required
+		return fieldDesc, true
+	}
+}
+
+// IsRequiredField checks if the field is required (proto2 only).
+// Returns true if the field has LABEL_REQUIRED, false otherwise.
+func IsRequiredField(field proto.Message) bool {
+	_, ok := AsRequiredField(field)
+	return ok
+}
+
+// AsScalarField checks if the field is a scalar type and returns it as a field descriptor.
+// Returns the field descriptor and true if it's a scalar field, nil and false otherwise.
+func AsScalarField(field proto.Message) (*descriptorpb.FieldDescriptorProto, bool) {
+	fieldDesc, ok := AsFieldType(field)
+	if !ok {
+		// Wrong type or missing Type field
+		return nil, false
+	}
+
+	switch *fieldDesc.Type {
+	case TypeDouble, TypeFloat,
+		TypeInt64, TypeUInt64, TypeInt32, TypeUInt32,
+		TypeFixed64, TypeFixed32,
+		TypeSFixed32, TypeSFixed64,
+		TypeSInt32, TypeSInt64,
+		TypeBool, TypeString, TypeBytes:
+		return fieldDesc, true
+	default:
+		return nil, false
+	}
+}
+
+// IsScalarField checks if the field is a scalar type.
+// Returns true if the field is a scalar protobuf type, false otherwise.
+func IsScalarField(field proto.Message) bool {
+	_, ok := AsScalarField(field)
+	return ok
+}
+
+// AsMessageField checks if the field is a message type and returns it as a field descriptor.
+// Returns the field descriptor and true if it's a TYPE_MESSAGE field, nil and false otherwise.
+// Note: This does not include TYPE_GROUP fields. Use AsGroupField for groups.
+func AsMessageField(field proto.Message) (*descriptorpb.FieldDescriptorProto, bool) {
+	fieldDesc, ok := AsFieldType(field)
+	if ok && isPointerEqual(fieldDesc.Type, TypeMessage) {
+		return fieldDesc, true
+	}
+	return nil, false
+}
+
+// IsMessageField checks if the field is a message type.
+// Returns true if the field is TYPE_MESSAGE, false otherwise.
+// Note: This does not include TYPE_GROUP fields. Use IsGroupField for groups.
+func IsMessageField(field proto.Message) bool {
+	_, ok := AsMessageField(field)
+	return ok
+}
+
+// AsGroupField checks if the field is a group type and returns it as a field descriptor.
+// Returns the field descriptor and true if it's a TYPE_GROUP field, nil and false otherwise.
+// Note: Groups are deprecated in proto2 and not supported in proto3. Use message types instead.
+func AsGroupField(field proto.Message) (*descriptorpb.FieldDescriptorProto, bool) {
+	fieldDesc, ok := AsFieldType(field)
+	if ok && isPointerEqual(fieldDesc.Type, TypeGroup) {
+		return fieldDesc, true
+	}
+	return nil, false
+}
+
+// IsGroupField checks if the field is a group type.
+// Returns true if the field is TYPE_GROUP, false otherwise.
+// Note: Groups are deprecated in proto2 and not supported in proto3. Use message types instead.
+func IsGroupField(field proto.Message) bool {
+	_, ok := AsGroupField(field)
+	return ok
+}
+
+// AsEnumField checks if the field is an enum type and returns it as a field descriptor.
+// Returns the field descriptor and true if it's an enum field, nil and false otherwise.
+func AsEnumField(field proto.Message) (*descriptorpb.FieldDescriptorProto, bool) {
+	fieldDesc, ok := AsFieldType(field)
+	if ok && isPointerEqual(fieldDesc.Type, TypeEnum) {
+		return fieldDesc, true
+	}
+	return nil, false
+}
+
+// IsEnumField checks if the field is an enum type.
+// Returns true if the field is TYPE_ENUM, false otherwise.
+func IsEnumField(field proto.Message) bool {
+	_, ok := AsEnumField(field)
+	return ok
+}
+
+func isPointerEqual[T comparable](p *T, v T) bool {
+	return p != nil && *p == v
+}
+
+func isPointerNonZero[T comparable](p *T) bool {
+	var zero T
+	return p != nil && *p != zero
+}

--- a/generator/descriptor_test.go
+++ b/generator/descriptor_test.go
@@ -1,0 +1,596 @@
+package generator
+
+import (
+	"fmt"
+	"testing"
+
+	"darvaza.org/core"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+// Compile-time verification that test case types implement TestCase interface
+var _ core.TestCase = isMessageWithNameTestCase{}
+var _ core.TestCase = boolCheckTestCase{}
+var _ core.TestCase = mapFieldWithMessageTestCase{}
+
+// Test case for IsMessageWithName which has a different signature
+type isMessageWithNameTestCase struct {
+	name     string
+	desc     proto.Message
+	typeName string
+	expected bool
+}
+
+func newIsMessageWithNameTestCase(name string, desc proto.Message,
+	typeName string, expected bool) isMessageWithNameTestCase {
+	return isMessageWithNameTestCase{
+		name:     name,
+		desc:     desc,
+		typeName: typeName,
+		expected: expected,
+	}
+}
+
+func (tc isMessageWithNameTestCase) Name() string {
+	return tc.name
+}
+
+func (tc isMessageWithNameTestCase) Test(t *testing.T) {
+	t.Helper()
+	result := IsMessageWithName(tc.desc, tc.typeName)
+	core.AssertEqual(t, tc.expected, result, "IsMessageWithName")
+}
+
+// Generic test case for boolean check functions that take a proto.Message
+type boolCheckTestCase struct {
+	// Larger fields first for field alignment
+	checkFn  func(proto.Message) bool
+	desc     proto.Message
+	name     string
+	fnName   string // For better error messages
+	expected bool
+}
+
+// Base factory function with all parameters
+func newBoolCheckTestCase(name string, desc proto.Message, expected bool,
+	checkFn func(proto.Message) bool, fnName string) boolCheckTestCase {
+	return boolCheckTestCase{
+		name:     name,
+		desc:     desc,
+		expected: expected,
+		checkFn:  checkFn,
+		fnName:   fnName,
+	}
+}
+
+func (tc boolCheckTestCase) Name() string {
+	return tc.name
+}
+
+func (tc boolCheckTestCase) Test(t *testing.T) {
+	t.Helper()
+	result := tc.checkFn(tc.desc)
+	core.AssertEqual(t, tc.expected, result, tc.fnName)
+}
+
+// Type-specific factory functions for better readability
+
+// newIsMessageTestCase creates a test case for IsMessage function
+func newIsMessageTestCase(name string, desc proto.Message, expected bool) boolCheckTestCase {
+	return newBoolCheckTestCase(name, desc, expected, IsMessage, "IsMessage")
+}
+
+// newIsFieldTypeTestCase creates a test case for IsFieldType function
+func newIsFieldTypeTestCase(name string, desc proto.Message, expected bool) boolCheckTestCase {
+	return newBoolCheckTestCase(name, desc, expected, IsFieldType, "IsFieldType")
+}
+
+// newIsServiceTypeTestCase creates a test case for IsServiceType function
+func newIsServiceTypeTestCase(name string, desc proto.Message, expected bool) boolCheckTestCase {
+	return newBoolCheckTestCase(name, desc, expected, IsServiceType, "IsServiceType")
+}
+
+// newIsMethodTypeTestCase creates a test case for IsMethodType function
+func newIsMethodTypeTestCase(name string, desc proto.Message, expected bool) boolCheckTestCase {
+	return newBoolCheckTestCase(name, desc, expected, IsMethodType, "IsMethodType")
+}
+
+// newIsEnumTypeTestCase creates a test case for IsEnumType function
+func newIsEnumTypeTestCase(name string, desc proto.Message, expected bool) boolCheckTestCase {
+	return newBoolCheckTestCase(name, desc, expected, IsEnumType, "IsEnumType")
+}
+
+// newIsFileTypeTestCase creates a test case for IsFileType function
+func newIsFileTypeTestCase(name string, desc proto.Message, expected bool) boolCheckTestCase {
+	return newBoolCheckTestCase(name, desc, expected, IsFileType, "IsFileType")
+}
+
+// newIsRepeatedFieldTestCase creates a test case for IsRepeatedField function
+func newIsRepeatedFieldTestCase(name string, field proto.Message, expected bool) boolCheckTestCase {
+	return newBoolCheckTestCase(name, field, expected, IsRepeatedField, "IsRepeatedField")
+}
+
+// newIsMapFieldTestCase creates a test case for IsMapField function
+func newIsMapFieldTestCase(name string, field proto.Message, expected bool) boolCheckTestCase {
+	return newBoolCheckTestCase(name, field, expected, IsMapField, "IsMapField")
+}
+
+// newIsOneOfFieldTestCase creates a test case for IsOneOfField function
+func newIsOneOfFieldTestCase(name string, field proto.Message, expected bool) boolCheckTestCase {
+	return newBoolCheckTestCase(name, field, expected, IsOneOfField, "IsOneOfField")
+}
+
+// newIsOptionalFieldTestCase creates a test case for IsOptionalField function
+func newIsOptionalFieldTestCase(name string, field proto.Message, expected bool) boolCheckTestCase {
+	return newBoolCheckTestCase(name, field, expected, IsOptionalField, "IsOptionalField")
+}
+
+// newIsRequiredFieldTestCase creates a test case for IsRequiredField function
+func newIsRequiredFieldTestCase(name string, field proto.Message, expected bool) boolCheckTestCase {
+	return newBoolCheckTestCase(name, field, expected, IsRequiredField, "IsRequiredField")
+}
+
+// newIsScalarFieldTestCase creates a test case for IsScalarField function
+func newIsScalarFieldTestCase(name string, field proto.Message, expected bool) boolCheckTestCase {
+	return newBoolCheckTestCase(name, field, expected, IsScalarField, "IsScalarField")
+}
+
+// newIsMessageFieldTestCase creates a test case for IsMessageField function
+func newIsMessageFieldTestCase(name string, field proto.Message, expected bool) boolCheckTestCase {
+	return newBoolCheckTestCase(name, field, expected, IsMessageField, "IsMessageField")
+}
+
+// newIsEnumFieldTestCase creates a test case for IsEnumField function
+func newIsEnumFieldTestCase(name string, field proto.Message, expected bool) boolCheckTestCase {
+	return newBoolCheckTestCase(name, field, expected, IsEnumField, "IsEnumField")
+}
+
+// newIsGroupFieldTestCase creates a test case for IsGroupField function
+func newIsGroupFieldTestCase(name string, field proto.Message, expected bool) boolCheckTestCase {
+	return newBoolCheckTestCase(name, field, expected, IsGroupField, "IsGroupField")
+}
+
+// Test functions
+
+func TestIsMessage(t *testing.T) {
+	testCases := []boolCheckTestCase{
+		newIsMessageTestCase("message descriptor with name",
+			&descriptorpb.DescriptorProto{Name: proto.String("TestMessage")}, true),
+		newIsMessageTestCase("message descriptor without name",
+			&descriptorpb.DescriptorProto{}, false),
+		newIsMessageTestCase("field descriptor", &descriptorpb.FieldDescriptorProto{}, false),
+		newIsMessageTestCase("service descriptor", &descriptorpb.ServiceDescriptorProto{}, false),
+		newIsMessageTestCase("nil descriptor", nil, false),
+	}
+
+	core.RunTestCases(t, testCases)
+}
+
+func TestIsMessageWithName(t *testing.T) {
+	msgDesc := &descriptorpb.DescriptorProto{
+		Name: proto.String("TestMessage"),
+	}
+
+	testCases := []isMessageWithNameTestCase{
+		newIsMessageWithNameTestCase("matching message type", msgDesc, "TestMessage", true),
+		newIsMessageWithNameTestCase("non-matching message type", msgDesc, "OtherMessage", false),
+		newIsMessageWithNameTestCase("nil descriptor", nil, "TestMessage", false),
+		newIsMessageWithNameTestCase("empty type name matches any", msgDesc, "", true),
+		newIsMessageWithNameTestCase("wrong descriptor type",
+			&descriptorpb.FieldDescriptorProto{}, "TestMessage", false),
+	}
+
+	core.RunTestCases(t, testCases)
+}
+
+func isFieldTypeTestCases() []boolCheckTestCase {
+	fieldType := TypeString
+	fieldWithType := &descriptorpb.FieldDescriptorProto{Type: &fieldType}
+
+	return []boolCheckTestCase{
+		newIsFieldTypeTestCase("field descriptor with type", fieldWithType, true),
+		newIsFieldTypeTestCase("field descriptor without type", &descriptorpb.FieldDescriptorProto{}, false),
+		newIsFieldTypeTestCase("message descriptor", &descriptorpb.DescriptorProto{}, false),
+		newIsFieldTypeTestCase("service descriptor", &descriptorpb.ServiceDescriptorProto{}, false),
+		newIsFieldTypeTestCase("nil descriptor", nil, false),
+	}
+}
+
+func TestIsFieldType(t *testing.T) {
+	core.RunTestCases(t, isFieldTypeTestCases())
+}
+
+func TestIsServiceType(t *testing.T) {
+	testCases := []boolCheckTestCase{
+		newIsServiceTypeTestCase("service descriptor with name",
+			&descriptorpb.ServiceDescriptorProto{Name: proto.String("TestService")}, true),
+		newIsServiceTypeTestCase("service descriptor without name",
+			&descriptorpb.ServiceDescriptorProto{}, false),
+		newIsServiceTypeTestCase("message descriptor", &descriptorpb.DescriptorProto{}, false),
+		newIsServiceTypeTestCase("field descriptor", &descriptorpb.FieldDescriptorProto{}, false),
+		newIsServiceTypeTestCase("nil descriptor", nil, false),
+	}
+
+	core.RunTestCases(t, testCases)
+}
+
+func TestIsMethodType(t *testing.T) {
+	testCases := []boolCheckTestCase{
+		newIsMethodTypeTestCase("method descriptor with all fields",
+			&descriptorpb.MethodDescriptorProto{
+				Name:       proto.String("TestMethod"),
+				InputType:  proto.String(".TestRequest"),
+				OutputType: proto.String(".TestResponse"),
+			}, true),
+		newIsMethodTypeTestCase("method descriptor without name",
+			&descriptorpb.MethodDescriptorProto{
+				InputType:  proto.String(".TestRequest"),
+				OutputType: proto.String(".TestResponse"),
+			}, false),
+		newIsMethodTypeTestCase("method descriptor without input type",
+			&descriptorpb.MethodDescriptorProto{
+				Name:       proto.String("TestMethod"),
+				OutputType: proto.String(".TestResponse"),
+			}, false),
+		newIsMethodTypeTestCase("method descriptor without output type",
+			&descriptorpb.MethodDescriptorProto{
+				Name:      proto.String("TestMethod"),
+				InputType: proto.String(".TestRequest"),
+			}, false),
+		newIsMethodTypeTestCase("service descriptor", &descriptorpb.ServiceDescriptorProto{}, false),
+		newIsMethodTypeTestCase("message descriptor", &descriptorpb.DescriptorProto{}, false),
+		newIsMethodTypeTestCase("nil descriptor", nil, false),
+	}
+
+	core.RunTestCases(t, testCases)
+}
+
+func TestIsEnumType(t *testing.T) {
+	testCases := []boolCheckTestCase{
+		newIsEnumTypeTestCase("enum descriptor with name",
+			&descriptorpb.EnumDescriptorProto{Name: proto.String("TestEnum")}, true),
+		newIsEnumTypeTestCase("enum descriptor without name",
+			&descriptorpb.EnumDescriptorProto{}, false),
+		newIsEnumTypeTestCase("enum value descriptor", &descriptorpb.EnumValueDescriptorProto{}, false),
+		newIsEnumTypeTestCase("message descriptor", &descriptorpb.DescriptorProto{}, false),
+		newIsEnumTypeTestCase("nil descriptor", nil, false),
+	}
+
+	core.RunTestCases(t, testCases)
+}
+
+func TestIsFileType(t *testing.T) {
+	testCases := []boolCheckTestCase{
+		newIsFileTypeTestCase("file descriptor with name",
+			&descriptorpb.FileDescriptorProto{Name: proto.String("test.proto")}, true),
+		newIsFileTypeTestCase("file descriptor without name",
+			&descriptorpb.FileDescriptorProto{}, false),
+		newIsFileTypeTestCase("message descriptor", &descriptorpb.DescriptorProto{}, false),
+		newIsFileTypeTestCase("service descriptor", &descriptorpb.ServiceDescriptorProto{}, false),
+		newIsFileTypeTestCase("nil descriptor", nil, false),
+	}
+
+	core.RunTestCases(t, testCases)
+}
+
+func isRepeatedFieldTestCases() []boolCheckTestCase {
+	repeatedField := NewFieldWithLabel(LabelRepeated)
+	optionalField := NewFieldWithLabel(LabelOptional)
+
+	return []boolCheckTestCase{
+		newIsRepeatedFieldTestCase("repeated field", repeatedField, true),
+		newIsRepeatedFieldTestCase("optional field", optionalField, false),
+		newIsRepeatedFieldTestCase("nil field", nil, false),
+		newIsRepeatedFieldTestCase("wrong type", &descriptorpb.DescriptorProto{}, false),
+	}
+}
+
+func TestIsRepeatedField(t *testing.T) {
+	core.RunTestCases(t, isRepeatedFieldTestCases())
+}
+
+func isMapFieldTestCases() []boolCheckTestCase {
+	// In protobuf, map fields are represented as repeated message fields
+	// where the message type is a map entry (has map_entry option set to true)
+	// For testing purposes, we'll check if it's a repeated message field
+	// with a type name that contains "Entry" (simplified check)
+	mapField := NewRepeatedMessageField(".MapEntry")
+
+	// Another map field example
+	mapFieldWithOptions := NewRepeatedMessageField(".MyMapEntry")
+	mapFieldWithOptions.Options = &descriptorpb.FieldOptions{}
+
+	regularRepeated := NewRepeatedField("regular", 1, TypeString)
+
+	regularMessage := NewMessageField("message", 2, ".SomeMessage")
+
+	// Edge cases for AsMapField coverage
+	repeatedMessageNoTypeName := NewRepeatedMessageField("") // empty typename
+
+	repeatedMessageNoEntry := NewRepeatedMessageField(".SomeMessage") // Doesn't contain "Entry"
+
+	return []boolCheckTestCase{
+		newIsMapFieldTestCase("map field", mapField, true),
+		newIsMapFieldTestCase("map field with options", mapFieldWithOptions, true),
+		newIsMapFieldTestCase("regular repeated field", regularRepeated, false),
+		newIsMapFieldTestCase("regular message field", regularMessage, false),
+		newIsMapFieldTestCase("repeated message no typename", repeatedMessageNoTypeName, false),
+		newIsMapFieldTestCase("repeated message no entry in name", repeatedMessageNoEntry, false),
+		newIsMapFieldTestCase("nil field", nil, false),
+		newIsMapFieldTestCase("wrong type", &descriptorpb.DescriptorProto{}, false),
+	}
+}
+
+func TestIsMapField(t *testing.T) {
+	core.RunTestCases(t, isMapFieldTestCases())
+}
+
+// Test case for AsMapFieldWithMessage which has a different signature
+type mapFieldWithMessageTestCase struct {
+	field    proto.Message
+	entryMsg proto.Message
+	name     string
+	expected bool
+}
+
+func newMapFieldWithMessageTestCase(name string, field proto.Message,
+	entryMsg proto.Message, expected bool) mapFieldWithMessageTestCase {
+	return mapFieldWithMessageTestCase{
+		name:     name,
+		field:    field,
+		entryMsg: entryMsg,
+		expected: expected,
+	}
+}
+
+func (tc mapFieldWithMessageTestCase) Name() string {
+	return tc.name
+}
+
+func (tc mapFieldWithMessageTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	// Test AsMapFieldWithMessage
+	field, ok := AsMapFieldWithMessage(tc.field, tc.entryMsg)
+	core.AssertEqual(t, tc.expected, ok, "AsMapFieldWithMessage")
+	if tc.expected {
+		core.AssertNotNil(t, field, "field")
+	} else {
+		core.AssertNil(t, field, "field")
+	}
+
+	// Test IsMapFieldWithMessage
+	result := IsMapFieldWithMessage(tc.field, tc.entryMsg)
+	core.AssertEqual(t, tc.expected, result, "IsMapFieldWithMessage")
+}
+
+func mapFieldWithMessageTestCases() []mapFieldWithMessageTestCase {
+	// Create test data
+	mapField := NewRepeatedMessageField(".MapEntry")
+	regularField := NewField("regular", 1, TypeString)
+
+	// Map entry message with map_entry=true
+	mapEntryTrue := proto.Bool(true)
+	mapEntryMsg := &descriptorpb.DescriptorProto{
+		Name: proto.String("MapEntry"),
+		Options: &descriptorpb.MessageOptions{
+			MapEntry: mapEntryTrue,
+		},
+	}
+
+	// Regular message without map_entry option
+	regularMsg := &descriptorpb.DescriptorProto{
+		Name: proto.String("RegularMessage"),
+	}
+
+	// Message with map_entry=false
+	mapEntryFalse := proto.Bool(false)
+	notMapEntryMsg := &descriptorpb.DescriptorProto{
+		Name: proto.String("NotMapEntry"),
+		Options: &descriptorpb.MessageOptions{
+			MapEntry: mapEntryFalse,
+		},
+	}
+
+	return []mapFieldWithMessageTestCase{
+		newMapFieldWithMessageTestCase("map field with map entry message",
+			mapField, mapEntryMsg, true),
+		newMapFieldWithMessageTestCase("map field with regular message",
+			mapField, regularMsg, false),
+		newMapFieldWithMessageTestCase("map field with map_entry=false",
+			mapField, notMapEntryMsg, false),
+		newMapFieldWithMessageTestCase("regular field with map entry message",
+			regularField, mapEntryMsg, false),
+		newMapFieldWithMessageTestCase("nil field",
+			nil, mapEntryMsg, false),
+		newMapFieldWithMessageTestCase("nil entry message fallback to heuristic",
+			mapField, nil, true),
+		newMapFieldWithMessageTestCase("wrong field type",
+			&descriptorpb.DescriptorProto{}, mapEntryMsg, false),
+		newMapFieldWithMessageTestCase("wrong entry message type",
+			mapField, &descriptorpb.FieldDescriptorProto{}, false),
+	}
+}
+
+func TestAsMapFieldWithMessage(t *testing.T) {
+	core.RunTestCases(t, mapFieldWithMessageTestCases())
+}
+
+func isOneOfFieldTestCases() []boolCheckTestCase {
+	oneOfField := NewOneOfField("variant", 1, TypeString, 0)
+	regularField := NewField("regular", 2, TypeString)
+
+	return []boolCheckTestCase{
+		newIsOneOfFieldTestCase("OneOf field", oneOfField, true),
+		newIsOneOfFieldTestCase("regular field", regularField, false),
+		newIsOneOfFieldTestCase("nil field", nil, false),
+		newIsOneOfFieldTestCase("wrong type", &descriptorpb.DescriptorProto{}, false),
+	}
+}
+
+func TestIsOneOfField(t *testing.T) {
+	core.RunTestCases(t, isOneOfFieldTestCases())
+}
+
+func isOptionalFieldTestCases() []boolCheckTestCase {
+	optionalField := NewField("optional", 1, TypeString)
+	requiredField := NewRequiredField("required", 2, TypeString)
+
+	// Proto3 optional needs special handling
+	proto3Optional := NewField("proto3_optional", 3, TypeString)
+	proto3Optional.Proto3Optional = proto.Bool(true)
+
+	// Proto3 singular field (has LABEL_OPTIONAL but Proto3Optional=false)
+	// This represents a regular proto3 field without the 'optional' keyword
+	proto3Singular := NewField("proto3_singular", 4, TypeString)
+	proto3Singular.Proto3Optional = proto.Bool(false)
+
+	return []boolCheckTestCase{
+		newIsOptionalFieldTestCase("optional field", optionalField, true),
+		newIsOptionalFieldTestCase("proto3 optional field", proto3Optional, true),
+		newIsOptionalFieldTestCase("proto3 singular field", proto3Singular, true),
+		newIsOptionalFieldTestCase("required field", requiredField, false),
+		newIsOptionalFieldTestCase("nil field", nil, false),
+		newIsOptionalFieldTestCase("wrong type", &descriptorpb.DescriptorProto{}, false),
+	}
+}
+
+func TestIsOptionalField(t *testing.T) {
+	core.RunTestCases(t, isOptionalFieldTestCases())
+}
+
+func isRequiredFieldTestCases() []boolCheckTestCase {
+	requiredField := NewRequiredField("required", 1, TypeString)
+	optionalField := NewField("optional", 2, TypeString)
+
+	return []boolCheckTestCase{
+		newIsRequiredFieldTestCase("required field", requiredField, true),
+		newIsRequiredFieldTestCase("optional field", optionalField, false),
+		newIsRequiredFieldTestCase("nil field", nil, false),
+		newIsRequiredFieldTestCase("wrong type", &descriptorpb.DescriptorProto{}, false),
+	}
+}
+
+func TestIsRequiredField(t *testing.T) {
+	core.RunTestCases(t, isRequiredFieldTestCases())
+}
+
+func isScalarFieldTestCases() []boolCheckTestCase {
+	scalarFields := []proto.Message{
+		NewField("double", 1, TypeDouble),
+		NewField("float", 2, TypeFloat),
+		NewField("int64", 3, TypeInt64),
+		NewField("int32", 5, TypeInt32),
+		NewField("fixed64", 6, TypeFixed64),
+		NewField("fixed32", 7, TypeFixed32),
+		NewField("bool", 8, TypeBool),
+		NewField("string", 9, TypeString),
+		NewField("bytes", 10, TypeBytes),
+		NewField("u_int32", 11, TypeUInt32),
+		NewField("u_int64", 4, TypeUInt64),
+		NewField("s_fixed32", 12, TypeSFixed32),
+		NewField("s_fixed64", 13, TypeSFixed64),
+		NewField("s_int32", 14, TypeSInt32),
+		NewField("s_int64", 15, TypeSInt64),
+	}
+
+	testCases := []boolCheckTestCase{}
+
+	// Add positive test cases for all scalar types
+	for i, field := range scalarFields {
+		name := fmt.Sprintf("scalar field %d", i+1)
+		testCases = append(testCases, newIsScalarFieldTestCase(name, field, true))
+	}
+
+	// Add negative test cases
+	messageField := NewMessageField("message", 16, ".example.Message")
+	enumField := NewEnumField("enum", 17, ".example.Enum")
+	groupField := NewField("group", 18, TypeGroup)
+
+	// With Label but no type
+	labelOptional := LabelOptional
+	fieldWithoutType := &descriptorpb.FieldDescriptorProto{Label: &labelOptional}
+
+	testCases = append(testCases,
+		newIsScalarFieldTestCase("message field", messageField, false),
+		newIsScalarFieldTestCase("enum field", enumField, false),
+		newIsScalarFieldTestCase("group field", groupField, false),
+		newIsScalarFieldTestCase("field without type", fieldWithoutType, false),
+		newIsScalarFieldTestCase("nil field", nil, false),
+		newIsScalarFieldTestCase("wrong type", &descriptorpb.DescriptorProto{}, false),
+	)
+
+	return testCases
+}
+
+func TestIsScalarField(t *testing.T) {
+	core.RunTestCases(t, isScalarFieldTestCases())
+}
+
+func isMessageFieldTestCases() []boolCheckTestCase {
+	messageField := NewFieldWithType(TypeMessage)
+	groupField := NewFieldWithType(TypeGroup)
+	scalarField := NewFieldWithType(TypeString)
+	enumField := NewFieldWithType(TypeEnum)
+
+	// With label but no type
+	labelOptional := LabelOptional
+	fieldWithoutType := &descriptorpb.FieldDescriptorProto{Label: &labelOptional}
+
+	return []boolCheckTestCase{
+		newIsMessageFieldTestCase("message field", messageField, true),
+		newIsMessageFieldTestCase("group field", groupField, false), // GROUP is separate from MESSAGE
+		newIsMessageFieldTestCase("scalar field", scalarField, false),
+		newIsMessageFieldTestCase("enum field", enumField, false),
+		newIsMessageFieldTestCase("field without type", fieldWithoutType, false),
+		newIsMessageFieldTestCase("nil field", nil, false),
+		newIsMessageFieldTestCase("wrong type", &descriptorpb.DescriptorProto{}, false),
+	}
+}
+
+func TestIsMessageField(t *testing.T) {
+	core.RunTestCases(t, isMessageFieldTestCases())
+}
+
+func isGroupFieldTestCases() []boolCheckTestCase {
+	groupField := NewFieldWithType(TypeGroup)
+	messageField := NewFieldWithType(TypeMessage)
+	scalarField := NewFieldWithType(TypeString)
+	enumField := NewFieldWithType(TypeEnum)
+
+	labelOptional := LabelOptional
+	fieldWithoutType := &descriptorpb.FieldDescriptorProto{Label: &labelOptional} // Has label but no type
+
+	return []boolCheckTestCase{
+		newIsGroupFieldTestCase("group field", groupField, true),
+		newIsGroupFieldTestCase("message field", messageField, false),
+		newIsGroupFieldTestCase("scalar field", scalarField, false),
+		newIsGroupFieldTestCase("enum field", enumField, false),
+		newIsGroupFieldTestCase("field without type", fieldWithoutType, false),
+		newIsGroupFieldTestCase("nil field", nil, false),
+		newIsGroupFieldTestCase("wrong type", &descriptorpb.DescriptorProto{}, false),
+	}
+}
+
+func TestIsGroupField(t *testing.T) {
+	core.RunTestCases(t, isGroupFieldTestCases())
+}
+
+func isEnumFieldTestCases() []boolCheckTestCase {
+	enumField := NewFieldWithType(TypeEnum)
+	scalarField := NewFieldWithType(TypeInt32)
+	messageField := NewFieldWithType(TypeMessage)
+
+	return []boolCheckTestCase{
+		newIsEnumFieldTestCase("enum field", enumField, true),
+		newIsEnumFieldTestCase("scalar field", scalarField, false),
+		newIsEnumFieldTestCase("message field", messageField, false),
+		newIsEnumFieldTestCase("nil field", nil, false),
+		newIsEnumFieldTestCase("wrong type", &descriptorpb.DescriptorProto{}, false),
+	}
+}
+
+func TestIsEnumField(t *testing.T) {
+	core.RunTestCases(t, isEnumFieldTestCases())
+}

--- a/generator/doc.go
+++ b/generator/doc.go
@@ -1,14 +1,31 @@
-// Package generator is a PLACEHOLDER module demonstrating the planned
-// architecture for common utilities for protoc plugin development.
+// Package generator provides utilities for protoc plugin development.
 //
-// ⚠️ WARNING: This package is not yet implemented. It exists only as a
-// placeholder to show the intended structure and planned features.
+// Currently provides test utilities for creating descriptor objects:
+//   - NewField - create optional field with scalar type.
+//   - NewRepeatedField - create repeated field.
+//   - NewRequiredField - create required field (proto2).
+//   - NewMessageField - create message type field.
+//   - NewEnumField - create enum type field.
+//   - NewMapField - create map field.
+//   - NewOneOfField - create oneof field.
+//   - NewFieldWithType - create minimal field with only type set.
+//   - NewFieldWithLabel - create minimal field with only label set.
+//   - NewRepeatedMessageField - create repeated message field.
+//   - NewMessage - create message descriptor.
+//   - NewMessageWithNested - create message with nested types.
+//   - NewEnum - create enum descriptor.
+//   - NewEnumValue - create enum value descriptor.
+//   - NewService - create service descriptor.
+//   - NewMethod - create method descriptor.
+//   - NewFile - create file descriptor.
+//   - NewFileWithTypes - create file with messages, enums, and services.
+//   - NewOneOf - create oneof descriptor.
+//   - Type constants (TypeString, TypeInt32, etc.) for field types.
 //
-// When implemented, this package will provide:
-//   - Descriptor traversal and type checking utilities.
+// Future releases will add:
+//   - Descriptor type checking and classification utilities.
 //   - Path construction and naming helpers.
-//   - Helper functions for walking descriptor trees.
-//
-// The actual implementation will be added in future releases as the
-// protomcp.org ecosystem develops.
+//   - Visitor patterns for walking descriptor trees.
+//   - Code generation output management.
+//   - Context management for build environments.
 package generator

--- a/generator/doc.go
+++ b/generator/doc.go
@@ -1,6 +1,29 @@
 // Package generator provides utilities for protoc plugin development.
 //
-// Currently provides test utilities for creating descriptor objects:
+// This package includes:
+//
+// Descriptor type checking utilities:
+//   - AsMessage, IsMessage - for DescriptorProto
+//   - AsMessageWithName, IsMessageWithName - for DescriptorProto with name check
+//   - AsFieldType, IsFieldType - for FieldDescriptorProto
+//   - AsEnumType, IsEnumType - for EnumDescriptorProto
+//   - AsServiceType, IsServiceType - for ServiceDescriptorProto
+//   - AsMethodType, IsMethodType - for MethodDescriptorProto
+//   - AsFileType, IsFileType - for FileDescriptorProto
+//
+// Field classification utilities:
+//   - AsScalarField, IsScalarField - for scalar type fields
+//   - AsMessageField, IsMessageField - for message type fields (TYPE_MESSAGE only)
+//   - AsGroupField, IsGroupField - for group type fields (TYPE_GROUP, deprecated)
+//   - AsEnumField, IsEnumField - for enum type fields
+//   - AsRepeatedField, IsRepeatedField - for repeated fields
+//   - AsMapField, IsMapField - for map fields (heuristic check)
+//   - AsMapFieldWithMessage, IsMapFieldWithMessage - for map fields (definitive check)
+//   - AsOneOfField, IsOneOfField - for oneof fields
+//   - AsOptionalField, IsOptionalField - for optional fields
+//   - AsRequiredField, IsRequiredField - for required fields
+//
+// Test utilities for creating descriptor objects:
 //   - NewField - create optional field with scalar type.
 //   - NewRepeatedField - create repeated field.
 //   - NewRequiredField - create required field (proto2).
@@ -23,7 +46,7 @@
 //   - Type constants (TypeString, TypeInt32, etc.) for field types.
 //
 // Future releases will add:
-//   - Descriptor type checking and classification utilities.
+//   - Descriptor traversal utilities.
 //   - Path construction and naming helpers.
 //   - Visitor patterns for walking descriptor trees.
 //   - Code generation output management.

--- a/generator/doc.go
+++ b/generator/doc.go
@@ -1,0 +1,14 @@
+// Package generator is a PLACEHOLDER module demonstrating the planned
+// architecture for common utilities for protoc plugin development.
+//
+// ⚠️ WARNING: This package is not yet implemented. It exists only as a
+// placeholder to show the intended structure and planned features.
+//
+// When implemented, this package will provide:
+//   - Descriptor traversal and type checking utilities.
+//   - Path construction and naming helpers.
+//   - Helper functions for walking descriptor trees.
+//
+// The actual implementation will be added in future releases as the
+// protomcp.org ecosystem develops.
+package generator

--- a/generator/go.mod
+++ b/generator/go.mod
@@ -1,3 +1,14 @@
 module protomcp.org/common/generator
 
 go 1.23.0
+
+// ours
+require darvaza.org/core v0.18.1
+
+// third-party
+require google.golang.org/protobuf v1.36.7
+
+require (
+	golang.org/x/net v0.42.0 // indirect
+	golang.org/x/text v0.27.0 // indirect
+)

--- a/generator/go.mod
+++ b/generator/go.mod
@@ -1,0 +1,3 @@
+module protomcp.org/common/generator
+
+go 1.23.0

--- a/generator/go.sum
+++ b/generator/go.sum
@@ -1,0 +1,12 @@
+darvaza.org/core v0.18.1 h1:d7yqVGRSj8ZNy1cLaY/7cSZQAZ9+yeTw8p+PI8iCmWA=
+darvaza.org/core v0.18.1/go.mod h1:kc6mS+nBKf4FMbGQ1OqOEkMt58gpX4qzs8eYiMH99ME=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+golang.org/x/net v0.42.0 h1:jzkYrhi3YQWD6MLBJcsklgQsoAcw89EcZbJw8Z614hs=
+golang.org/x/net v0.42.0/go.mod h1:FF1RA5d3u7nAYA4z2TkclSCKh68eSXtiFwcWQpPXdt8=
+golang.org/x/text v0.27.0 h1:4fGWRpyh641NLlecmyl4LOe6yDdfaYNrGb2zdfo4JV4=
+golang.org/x/text v0.27.0/go.mod h1:1D28KMCvyooCX9hBiosv5Tz/+YLxj0j7XhWjpSUF7CU=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+google.golang.org/protobuf v1.36.7 h1:IgrO7UwFQGJdRNXH/sQux4R1Dj1WAKcLElzeeRaXV2A=
+google.golang.org/protobuf v1.36.7/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/5YcXBHnY=

--- a/generator/testutils.go
+++ b/generator/testutils.go
@@ -1,0 +1,237 @@
+package generator
+
+import (
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+// Test utility functions for creating protobuf descriptors
+// These are only used in tests and provide convenient shortcuts
+
+// NewField creates a field descriptor with the given name and type.
+// Returns a FieldDescriptorProto with LABEL_OPTIONAL.
+func NewField(name string, number int32,
+	fieldType descriptorpb.FieldDescriptorProto_Type) *descriptorpb.FieldDescriptorProto {
+	label := LabelOptional
+	return &descriptorpb.FieldDescriptorProto{
+		Name:   proto.String(name),
+		Number: proto.Int32(number),
+		Label:  &label,
+		Type:   &fieldType,
+	}
+}
+
+// NewRepeatedField creates a repeated field descriptor.
+// Returns a FieldDescriptorProto with LABEL_REPEATED.
+func NewRepeatedField(name string, number int32,
+	fieldType descriptorpb.FieldDescriptorProto_Type) *descriptorpb.FieldDescriptorProto {
+	label := LabelRepeated
+	return &descriptorpb.FieldDescriptorProto{
+		Name:   proto.String(name),
+		Number: proto.Int32(number),
+		Label:  &label,
+		Type:   &fieldType,
+	}
+}
+
+// NewRequiredField creates a required field descriptor (proto2).
+// Returns a FieldDescriptorProto with LABEL_REQUIRED.
+func NewRequiredField(name string, number int32,
+	fieldType descriptorpb.FieldDescriptorProto_Type) *descriptorpb.FieldDescriptorProto {
+	label := LabelRequired
+	return &descriptorpb.FieldDescriptorProto{
+		Name:   proto.String(name),
+		Number: proto.Int32(number),
+		Label:  &label,
+		Type:   &fieldType,
+	}
+}
+
+// NewMessageField creates a message type field descriptor.
+// Returns a FieldDescriptorProto with TYPE_MESSAGE and the given type name.
+func NewMessageField(name string, number int32, typeName string) *descriptorpb.FieldDescriptorProto {
+	label := LabelOptional
+	msgType := TypeMessage
+	return &descriptorpb.FieldDescriptorProto{
+		Name:     proto.String(name),
+		Number:   proto.Int32(number),
+		Label:    &label,
+		Type:     &msgType,
+		TypeName: proto.String(typeName),
+	}
+}
+
+// NewEnumField creates an enum type field descriptor.
+// Returns a FieldDescriptorProto with TYPE_ENUM and the given type name.
+func NewEnumField(name string, number int32, typeName string) *descriptorpb.FieldDescriptorProto {
+	label := LabelOptional
+	enumType := TypeEnum
+	return &descriptorpb.FieldDescriptorProto{
+		Name:     proto.String(name),
+		Number:   proto.Int32(number),
+		Label:    &label,
+		Type:     &enumType,
+		TypeName: proto.String(typeName),
+	}
+}
+
+// NewMapField creates a map field descriptor.
+// Note: This creates a repeated message field with the given entry type name.
+// The actual map entry message with map_entry option should be defined separately.
+func NewMapField(name string, number int32, entryTypeName string) *descriptorpb.FieldDescriptorProto {
+	label := LabelRepeated
+	msgType := TypeMessage
+	return &descriptorpb.FieldDescriptorProto{
+		Name:     proto.String(name),
+		Number:   proto.Int32(number),
+		Label:    &label,
+		Type:     &msgType,
+		TypeName: proto.String(entryTypeName),
+	}
+}
+
+// NewOneOfField creates a field that's part of a oneof.
+// Returns a FieldDescriptorProto with the given oneof index.
+func NewOneOfField(name string, number int32,
+	fieldType descriptorpb.FieldDescriptorProto_Type,
+	oneOfIndex int32) *descriptorpb.FieldDescriptorProto {
+	label := LabelOptional
+	return &descriptorpb.FieldDescriptorProto{
+		Name:       proto.String(name),
+		Number:     proto.Int32(number),
+		Label:      &label,
+		Type:       &fieldType,
+		OneofIndex: proto.Int32(oneOfIndex),
+	}
+}
+
+// NewMessage creates a message descriptor with the given name.
+// Returns a DescriptorProto with the provided fields.
+func NewMessage(name string, fields ...*descriptorpb.FieldDescriptorProto) *descriptorpb.DescriptorProto {
+	return &descriptorpb.DescriptorProto{
+		Name:  proto.String(name),
+		Field: fields,
+	}
+}
+
+// NewMessageWithNested creates a message with nested types.
+// Returns a DescriptorProto with nested messages and enums.
+func NewMessageWithNested(name string, fields []*descriptorpb.FieldDescriptorProto,
+	nestedMessages []*descriptorpb.DescriptorProto,
+	nestedEnums []*descriptorpb.EnumDescriptorProto) *descriptorpb.DescriptorProto {
+	return &descriptorpb.DescriptorProto{
+		Name:       proto.String(name),
+		Field:      fields,
+		NestedType: nestedMessages,
+		EnumType:   nestedEnums,
+	}
+}
+
+// NewEnum creates an enum descriptor with the given name and values.
+// Returns an EnumDescriptorProto with values numbered from 0.
+func NewEnum(name string, values ...string) *descriptorpb.EnumDescriptorProto {
+	enumValues := make([]*descriptorpb.EnumValueDescriptorProto, len(values))
+	for i, v := range values {
+		enumValues[i] = &descriptorpb.EnumValueDescriptorProto{
+			Name:   proto.String(v),
+			Number: proto.Int32(int32(i)),
+		}
+	}
+	return &descriptorpb.EnumDescriptorProto{
+		Name:  proto.String(name),
+		Value: enumValues,
+	}
+}
+
+// NewEnumValue creates an enum value descriptor.
+// Returns an EnumValueDescriptorProto with the given name and number.
+func NewEnumValue(name string, number int32) *descriptorpb.EnumValueDescriptorProto {
+	return &descriptorpb.EnumValueDescriptorProto{
+		Name:   proto.String(name),
+		Number: proto.Int32(number),
+	}
+}
+
+// NewService creates a service descriptor with the given name.
+// Returns a ServiceDescriptorProto with the provided methods.
+func NewService(name string, methods ...*descriptorpb.MethodDescriptorProto) *descriptorpb.ServiceDescriptorProto {
+	return &descriptorpb.ServiceDescriptorProto{
+		Name:   proto.String(name),
+		Method: methods,
+	}
+}
+
+// NewMethod creates a method descriptor.
+// Returns a MethodDescriptorProto with the given input and output types.
+func NewMethod(name, inputType, outputType string) *descriptorpb.MethodDescriptorProto {
+	return &descriptorpb.MethodDescriptorProto{
+		Name:       proto.String(name),
+		InputType:  proto.String(inputType),
+		OutputType: proto.String(outputType),
+	}
+}
+
+// NewFile creates a file descriptor with the given name and package.
+// Returns a FileDescriptorProto with basic metadata.
+func NewFile(name, pkg string) *descriptorpb.FileDescriptorProto {
+	return &descriptorpb.FileDescriptorProto{
+		Name:    proto.String(name),
+		Package: proto.String(pkg),
+	}
+}
+
+// NewFileWithTypes creates a file descriptor with various types.
+// Returns a FileDescriptorProto with messages, enums, and services.
+func NewFileWithTypes(name, pkg string,
+	messages []*descriptorpb.DescriptorProto,
+	enums []*descriptorpb.EnumDescriptorProto,
+	services []*descriptorpb.ServiceDescriptorProto) *descriptorpb.FileDescriptorProto {
+	return &descriptorpb.FileDescriptorProto{
+		Name:        proto.String(name),
+		Package:     proto.String(pkg),
+		MessageType: messages,
+		EnumType:    enums,
+		Service:     services,
+	}
+}
+
+// NewOneOf creates a oneof descriptor.
+// Returns a OneofDescriptorProto with the given name.
+func NewOneOf(name string) *descriptorpb.OneofDescriptorProto {
+	return &descriptorpb.OneofDescriptorProto{
+		Name: proto.String(name),
+	}
+}
+
+// NewFieldWithType creates a minimal field descriptor with only type set
+// Useful for testing type-checking functions
+func NewFieldWithType(fieldType descriptorpb.FieldDescriptorProto_Type) *descriptorpb.FieldDescriptorProto {
+	return &descriptorpb.FieldDescriptorProto{
+		Type: &fieldType,
+	}
+}
+
+// NewFieldWithLabel creates a minimal field descriptor with label and a default type
+// Useful for testing cardinality functions. Uses TYPE_STRING as default type.
+func NewFieldWithLabel(label descriptorpb.FieldDescriptorProto_Label) *descriptorpb.FieldDescriptorProto {
+	defaultType := TypeString
+	return &descriptorpb.FieldDescriptorProto{
+		Label: &label,
+		Type:  &defaultType,
+	}
+}
+
+// NewRepeatedMessageField creates a repeated message field with optional type name
+// Useful for map field testing and other repeated message scenarios
+func NewRepeatedMessageField(typeName string) *descriptorpb.FieldDescriptorProto {
+	label := LabelRepeated
+	msgType := TypeMessage
+	field := &descriptorpb.FieldDescriptorProto{
+		Label: &label,
+		Type:  &msgType,
+	}
+	if typeName != "" {
+		field.TypeName = proto.String(typeName)
+	}
+	return field
+}

--- a/generator/testutils_test.go
+++ b/generator/testutils_test.go
@@ -1,0 +1,421 @@
+package generator
+
+import (
+	"testing"
+
+	"darvaza.org/core"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+// Test NewField function
+func TestNewField(t *testing.T) {
+	field := NewField("test_field", 1, TypeString)
+
+	core.AssertNotNil(t, field, "field")
+	core.AssertEqual(t, "test_field", field.GetName(), "field name")
+	core.AssertEqual(t, int32(1), field.GetNumber(), "field number")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_STRING, field.GetType(), "field type")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL, field.GetLabel(), "field label")
+}
+
+// Test NewRepeatedField function
+func TestNewRepeatedField(t *testing.T) {
+	field := NewRepeatedField("items", 2, TypeInt32)
+
+	core.AssertNotNil(t, field, "field")
+	core.AssertEqual(t, "items", field.GetName(), "field name")
+	core.AssertEqual(t, int32(2), field.GetNumber(), "field number")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_INT32, field.GetType(), "field type")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_LABEL_REPEATED, field.GetLabel(), "field label")
+}
+
+// Test NewRequiredField function
+func TestNewRequiredField(t *testing.T) {
+	field := NewRequiredField("id", 3, TypeUInt64)
+
+	core.AssertNotNil(t, field, "field")
+	core.AssertEqual(t, "id", field.GetName(), "field name")
+	core.AssertEqual(t, int32(3), field.GetNumber(), "field number")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_UINT64, field.GetType(), "field type")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_LABEL_REQUIRED, field.GetLabel(), "field label")
+}
+
+// Test NewMessageField function
+func TestNewMessageField(t *testing.T) {
+	field := NewMessageField("user", 4, ".example.User")
+
+	core.AssertNotNil(t, field, "field")
+	core.AssertEqual(t, "user", field.GetName(), "field name")
+	core.AssertEqual(t, int32(4), field.GetNumber(), "field number")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_MESSAGE, field.GetType(), "field type")
+	core.AssertEqual(t, ".example.User", field.GetTypeName(), "field type name")
+}
+
+// Test NewEnumField function
+func TestNewEnumField(t *testing.T) {
+	field := NewEnumField("status", 5, ".example.Status")
+
+	core.AssertNotNil(t, field, "field")
+	core.AssertEqual(t, "status", field.GetName(), "field name")
+	core.AssertEqual(t, int32(5), field.GetNumber(), "field number")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_ENUM, field.GetType(), "field type")
+	core.AssertEqual(t, ".example.Status", field.GetTypeName(), "field type name")
+}
+
+// Test NewMapField function
+func TestNewMapField(t *testing.T) {
+	field := NewMapField("attributes", 6, ".AttributesEntry")
+
+	core.AssertNotNil(t, field, "field")
+	core.AssertEqual(t, "attributes", field.GetName(), "field name")
+	core.AssertEqual(t, int32(6), field.GetNumber(), "field number")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_MESSAGE, field.GetType(), "field type")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_LABEL_REPEATED, field.GetLabel(), "field label")
+	core.AssertEqual(t, ".AttributesEntry", field.GetTypeName(), "field type name")
+}
+
+// Test NewOneOfField function
+func TestNewOneOfField(t *testing.T) {
+	field := NewOneOfField("choice", 7, TypeBool, 0)
+
+	core.AssertNotNil(t, field, "field")
+	core.AssertEqual(t, "choice", field.GetName(), "field name")
+	core.AssertEqual(t, int32(7), field.GetNumber(), "field number")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_BOOL, field.GetType(), "field type")
+	core.AssertNotNil(t, field.OneofIndex, "oneof index")
+	core.AssertEqual(t, int32(0), *field.OneofIndex, "oneof index value")
+}
+
+// Test creating complex message structures
+func TestComplexMessageCreation(t *testing.T) {
+	// Create a message with various field types
+	msg := &descriptorpb.DescriptorProto{
+		Name: proto.String("TestMessage"),
+		Field: []*descriptorpb.FieldDescriptorProto{
+			NewField("id", 1, TypeInt64),
+			NewRepeatedField("tags", 2, TypeString),
+			NewMessageField("user", 3, ".example.User"),
+			NewEnumField("status", 4, ".example.Status"),
+			NewMapField("metadata", 5, ".MetadataEntry"),
+			NewOneOfField("variant", 6, TypeBool, 0),
+		},
+	}
+
+	core.AssertNotNil(t, msg, "message")
+	core.AssertEqual(t, "TestMessage", msg.GetName(), "message name")
+	core.AssertEqual(t, 6, len(msg.Field), "field count")
+
+	// Verify each field
+	core.AssertEqual(t, "id", msg.Field[0].GetName(), "field 0 name")
+	core.AssertEqual(t, "tags", msg.Field[1].GetName(), "field 1 name")
+	core.AssertEqual(t, "user", msg.Field[2].GetName(), "field 2 name")
+	core.AssertEqual(t, "status", msg.Field[3].GetName(), "field 3 name")
+	core.AssertEqual(t, "metadata", msg.Field[4].GetName(), "field 4 name")
+	core.AssertEqual(t, "variant", msg.Field[5].GetName(), "field 5 name")
+
+	// Verify field types
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_INT64, msg.Field[0].GetType(), "field 0 type")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_STRING, msg.Field[1].GetType(), "field 1 type")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_MESSAGE, msg.Field[2].GetType(), "field 2 type")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_ENUM, msg.Field[3].GetType(), "field 3 type")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_MESSAGE, msg.Field[4].GetType(), "field 4 type")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_BOOL, msg.Field[5].GetType(), "field 5 type")
+
+	// Verify labels
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL, msg.Field[0].GetLabel(), "field 0 label")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_LABEL_REPEATED, msg.Field[1].GetLabel(), "field 1 label")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_LABEL_REPEATED, msg.Field[4].GetLabel(), "field 4 label")
+}
+
+// Test field helpers with edge cases
+func TestFieldHelpersEdgeCases(t *testing.T) {
+	// Test with empty name
+	field := NewField("", 1, TypeString)
+	core.AssertEqual(t, "", field.GetName(), "empty name")
+
+	// Test with zero number
+	field = NewField("test", 0, TypeString)
+	core.AssertEqual(t, int32(0), field.GetNumber(), "zero number")
+
+	// Test with negative number
+	field = NewField("test", -1, TypeString)
+	core.AssertEqual(t, int32(-1), field.GetNumber(), "negative number")
+
+	// Test map field with empty name
+	field = NewMapField("", 1, ".Entry")
+	core.AssertEqual(t, "", field.GetName(), "empty map name")
+	core.AssertEqual(t, ".Entry", field.GetTypeName(), "empty map type name")
+
+	// Test oneof with large index
+	field = NewOneOfField("test", 1, TypeString, 999)
+	core.AssertNotNil(t, field.OneofIndex, "oneof index")
+	core.AssertEqual(t, int32(999), *field.OneofIndex, "large oneof index")
+}
+
+// Test NewMessage function
+func TestNewMessage(t *testing.T) {
+	fields := []*descriptorpb.FieldDescriptorProto{
+		NewField("id", 1, TypeInt64),
+		NewField("name", 2, TypeString),
+	}
+
+	msg := NewMessage("User", fields...)
+
+	core.AssertNotNil(t, msg, "message")
+	core.AssertEqual(t, "User", msg.GetName(), "message name")
+	core.AssertEqual(t, 2, len(msg.Field), "field count")
+	core.AssertEqual(t, "id", msg.Field[0].GetName(), "first field name")
+	core.AssertEqual(t, "name", msg.Field[1].GetName(), "second field name")
+
+	// Test with no fields
+	emptyMsg := NewMessage("Empty")
+	core.AssertNotNil(t, emptyMsg, "empty message")
+	core.AssertEqual(t, "Empty", emptyMsg.GetName(), "empty message name")
+	core.AssertEqual(t, 0, len(emptyMsg.Field), "empty field count")
+}
+
+// Test NewMessageWithNested function
+func TestNewMessageWithNested(t *testing.T) {
+	fields := []*descriptorpb.FieldDescriptorProto{
+		NewField("id", 1, TypeInt64),
+	}
+
+	nestedMessages := []*descriptorpb.DescriptorProto{
+		NewMessage("Nested", NewField("value", 1, TypeString)),
+	}
+
+	nestedEnums := []*descriptorpb.EnumDescriptorProto{
+		NewEnum("Status", "UNKNOWN", "ACTIVE", "INACTIVE"),
+	}
+
+	msg := NewMessageWithNested("ComplexMessage", fields, nestedMessages, nestedEnums)
+
+	core.AssertNotNil(t, msg, "message")
+	core.AssertEqual(t, "ComplexMessage", msg.GetName(), "message name")
+	core.AssertEqual(t, 1, len(msg.Field), "field count")
+	core.AssertEqual(t, 1, len(msg.NestedType), "nested message count")
+	core.AssertEqual(t, 1, len(msg.EnumType), "nested enum count")
+	core.AssertEqual(t, "Nested", msg.NestedType[0].GetName(), "nested message name")
+	core.AssertEqual(t, "Status", msg.EnumType[0].GetName(), "nested enum name")
+}
+
+// Test NewEnum function
+func TestNewEnum(t *testing.T) {
+	enum := NewEnum("Colour", "RED", "GREEN", "BLUE")
+
+	core.AssertNotNil(t, enum, "enum")
+	core.AssertEqual(t, "Colour", enum.GetName(), "enum name")
+	core.AssertEqual(t, 3, len(enum.Value), "value count")
+	core.AssertEqual(t, "RED", enum.Value[0].GetName(), "first value name")
+	core.AssertEqual(t, int32(0), enum.Value[0].GetNumber(), "first value number")
+	core.AssertEqual(t, "GREEN", enum.Value[1].GetName(), "second value name")
+	core.AssertEqual(t, int32(1), enum.Value[1].GetNumber(), "second value number")
+	core.AssertEqual(t, "BLUE", enum.Value[2].GetName(), "third value name")
+	core.AssertEqual(t, int32(2), enum.Value[2].GetNumber(), "third value number")
+
+	// Test with no values
+	emptyEnum := NewEnum("Empty")
+	core.AssertNotNil(t, emptyEnum, "empty enum")
+	core.AssertEqual(t, "Empty", emptyEnum.GetName(), "empty enum name")
+	core.AssertEqual(t, 0, len(emptyEnum.Value), "empty value count")
+}
+
+// Test NewEnumValue function
+func TestNewEnumValue(t *testing.T) {
+	value := NewEnumValue("SUCCESS", 42)
+
+	core.AssertNotNil(t, value, "enum value")
+	core.AssertEqual(t, "SUCCESS", value.GetName(), "value name")
+	core.AssertEqual(t, int32(42), value.GetNumber(), "value number")
+
+	// Test with negative number
+	negValue := NewEnumValue("ERROR", -1)
+	core.AssertNotNil(t, negValue, "negative enum value")
+	core.AssertEqual(t, "ERROR", negValue.GetName(), "negative value name")
+	core.AssertEqual(t, int32(-1), negValue.GetNumber(), "negative value number")
+}
+
+// Test NewService function
+func TestNewService(t *testing.T) {
+	methods := []*descriptorpb.MethodDescriptorProto{
+		NewMethod("GetUser", ".GetUserRequest", ".GetUserResponse"),
+		NewMethod("UpdateUser", ".UpdateUserRequest", ".UpdateUserResponse"),
+	}
+
+	service := NewService("UserService", methods...)
+
+	core.AssertNotNil(t, service, "service")
+	core.AssertEqual(t, "UserService", service.GetName(), "service name")
+	core.AssertEqual(t, 2, len(service.Method), "method count")
+	core.AssertEqual(t, "GetUser", service.Method[0].GetName(), "first method name")
+	core.AssertEqual(t, "UpdateUser", service.Method[1].GetName(), "second method name")
+
+	// Test with no methods
+	emptyService := NewService("EmptyService")
+	core.AssertNotNil(t, emptyService, "empty service")
+	core.AssertEqual(t, "EmptyService", emptyService.GetName(), "empty service name")
+	core.AssertEqual(t, 0, len(emptyService.Method), "empty method count")
+}
+
+// Test NewMethod function
+func TestNewMethod(t *testing.T) {
+	method := NewMethod("GetUser", ".GetUserRequest", ".GetUserResponse")
+
+	core.AssertNotNil(t, method, "method")
+	core.AssertEqual(t, "GetUser", method.GetName(), "method name")
+	core.AssertEqual(t, ".GetUserRequest", method.GetInputType(), "input type")
+	core.AssertEqual(t, ".GetUserResponse", method.GetOutputType(), "output type")
+
+	// Test with empty types
+	emptyMethod := NewMethod("Empty", "", "")
+	core.AssertNotNil(t, emptyMethod, "empty method")
+	core.AssertEqual(t, "Empty", emptyMethod.GetName(), "empty method name")
+	core.AssertEqual(t, "", emptyMethod.GetInputType(), "empty input type")
+	core.AssertEqual(t, "", emptyMethod.GetOutputType(), "empty output type")
+}
+
+// Test NewFile function
+func TestNewFile(t *testing.T) {
+	file := NewFile("user.proto", "example.user")
+
+	core.AssertNotNil(t, file, "file")
+	core.AssertEqual(t, "user.proto", file.GetName(), "file name")
+	core.AssertEqual(t, "example.user", file.GetPackage(), "package name")
+
+	// Test with empty values
+	emptyFile := NewFile("", "")
+	core.AssertNotNil(t, emptyFile, "empty file")
+	core.AssertEqual(t, "", emptyFile.GetName(), "empty file name")
+	core.AssertEqual(t, "", emptyFile.GetPackage(), "empty package name")
+}
+
+// Test NewFileWithTypes function
+func TestNewFileWithTypes(t *testing.T) {
+	messages := []*descriptorpb.DescriptorProto{
+		NewMessage("User", NewField("id", 1, TypeInt64)),
+		NewMessage("Profile", NewField("bio", 1, TypeString)),
+	}
+
+	enums := []*descriptorpb.EnumDescriptorProto{
+		NewEnum("Status", "ACTIVE", "INACTIVE"),
+	}
+
+	services := []*descriptorpb.ServiceDescriptorProto{
+		NewService("UserService", NewMethod("GetUser", ".GetUserRequest", ".GetUserResponse")),
+	}
+
+	file := NewFileWithTypes("api.proto", "example.api", messages, enums, services)
+
+	core.AssertNotNil(t, file, "file")
+	core.AssertEqual(t, "api.proto", file.GetName(), "file name")
+	core.AssertEqual(t, "example.api", file.GetPackage(), "package name")
+	core.AssertEqual(t, 2, len(file.MessageType), "message count")
+	core.AssertEqual(t, 1, len(file.EnumType), "enum count")
+	core.AssertEqual(t, 1, len(file.Service), "service count")
+	core.AssertEqual(t, "User", file.MessageType[0].GetName(), "first message name")
+	core.AssertEqual(t, "Profile", file.MessageType[1].GetName(), "second message name")
+	core.AssertEqual(t, "Status", file.EnumType[0].GetName(), "enum name")
+	core.AssertEqual(t, "UserService", file.Service[0].GetName(), "service name")
+
+	// Test with nil slices
+	nilFile := NewFileWithTypes("nil.proto", "example", nil, nil, nil)
+	core.AssertNotNil(t, nilFile, "nil file")
+	core.AssertEqual(t, 0, len(nilFile.MessageType), "nil message count")
+	core.AssertEqual(t, 0, len(nilFile.EnumType), "nil enum count")
+	core.AssertEqual(t, 0, len(nilFile.Service), "nil service count")
+}
+
+// Test NewOneOf function
+func TestNewOneOf(t *testing.T) {
+	oneof := NewOneOf("response")
+
+	core.AssertNotNil(t, oneof, "oneof")
+	core.AssertEqual(t, "response", oneof.GetName(), "oneof name")
+
+	// Test with empty name
+	emptyOneOf := NewOneOf("")
+	core.AssertNotNil(t, emptyOneOf, "empty oneof")
+	core.AssertEqual(t, "", emptyOneOf.GetName(), "empty oneof name")
+}
+
+// Test NewFieldWithType function
+func TestNewFieldWithType(t *testing.T) {
+	field := NewFieldWithType(TypeString)
+
+	core.AssertNotNil(t, field, "field")
+	core.AssertNotNil(t, field.Type, "field type")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_STRING, *field.Type, "field type value")
+	core.AssertNil(t, field.Name, "field name should be nil")
+	core.AssertNil(t, field.Number, "field number should be nil")
+	core.AssertNil(t, field.Label, "field label should be nil")
+
+	// Test with different types
+	messageField := NewFieldWithType(TypeMessage)
+	core.AssertNotNil(t, messageField, "message field")
+	core.AssertNotNil(t, messageField.Type, "message field type")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_MESSAGE, *messageField.Type, "message field type value")
+
+	enumField := NewFieldWithType(TypeEnum)
+	core.AssertNotNil(t, enumField, "enum field")
+	core.AssertNotNil(t, enumField.Type, "enum field type")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_ENUM, *enumField.Type, "enum field type value")
+}
+
+// Test NewFieldWithLabel function
+func TestNewFieldWithLabel(t *testing.T) {
+	field := NewFieldWithLabel(descriptorpb.FieldDescriptorProto_LABEL_REPEATED)
+
+	core.AssertNotNil(t, field, "field")
+	core.AssertNotNil(t, field.Label, "field label")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_LABEL_REPEATED, *field.Label, "field label value")
+	core.AssertNil(t, field.Name, "field name should be nil")
+	core.AssertNil(t, field.Number, "field number should be nil")
+	// Now includes a default Type field for validity
+	core.AssertNotNil(t, field.Type, "field type")
+	core.AssertEqual(t, TypeString, *field.Type, "field type default")
+
+	// Test with different labels
+	optionalField := NewFieldWithLabel(descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL)
+	core.AssertNotNil(t, optionalField, "optional field")
+	core.AssertNotNil(t, optionalField.Label, "optional field label")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL,
+		*optionalField.Label, "optional field label value")
+	core.AssertNotNil(t, optionalField.Type, "optional field type")
+
+	requiredField := NewFieldWithLabel(descriptorpb.FieldDescriptorProto_LABEL_REQUIRED)
+	core.AssertNotNil(t, requiredField, "required field")
+	core.AssertNotNil(t, requiredField.Label, "required field label")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_LABEL_REQUIRED,
+		*requiredField.Label, "required field label value")
+	core.AssertNotNil(t, requiredField.Type, "required field type")
+}
+
+// Test NewRepeatedMessageField function
+func TestNewRepeatedMessageField(t *testing.T) {
+	// Test with type name
+	field := NewRepeatedMessageField(".example.Message")
+
+	core.AssertNotNil(t, field, "field")
+	core.AssertNotNil(t, field.Label, "field label")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_LABEL_REPEATED, *field.Label, "field label value")
+	core.AssertNotNil(t, field.Type, "field type")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_MESSAGE, *field.Type, "field type value")
+	core.AssertNotNil(t, field.TypeName, "field type name")
+	core.AssertEqual(t, ".example.Message", *field.TypeName, "field type name value")
+
+	// Test with empty type name (should not set TypeName)
+	emptyField := NewRepeatedMessageField("")
+	core.AssertNotNil(t, emptyField, "empty field")
+	core.AssertNotNil(t, emptyField.Label, "empty field label")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_LABEL_REPEATED, *emptyField.Label, "empty field label value")
+	core.AssertNotNil(t, emptyField.Type, "empty field type")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_MESSAGE, *emptyField.Type, "empty field type value")
+	core.AssertNil(t, emptyField.TypeName, "empty field type name should be nil")
+
+	// Test for map field pattern
+	mapField := NewRepeatedMessageField(".MapEntry")
+	core.AssertNotNil(t, mapField, "map field")
+	core.AssertNotNil(t, mapField.TypeName, "map field type name")
+	core.AssertEqual(t, ".MapEntry", *mapField.TypeName, "map field type name value")
+}

--- a/generator/types.go
+++ b/generator/types.go
@@ -1,0 +1,41 @@
+package generator
+
+import (
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+// Field type aliases for common protobuf field types.
+// These provide shorter, more readable names for the descriptorpb constants.
+// cspell:ignore SFIXED SINT
+const (
+	// Numeric types
+	TypeDouble   = descriptorpb.FieldDescriptorProto_TYPE_DOUBLE
+	TypeFloat    = descriptorpb.FieldDescriptorProto_TYPE_FLOAT
+	TypeInt64    = descriptorpb.FieldDescriptorProto_TYPE_INT64
+	TypeUInt64   = descriptorpb.FieldDescriptorProto_TYPE_UINT64
+	TypeInt32    = descriptorpb.FieldDescriptorProto_TYPE_INT32
+	TypeFixed64  = descriptorpb.FieldDescriptorProto_TYPE_FIXED64
+	TypeFixed32  = descriptorpb.FieldDescriptorProto_TYPE_FIXED32
+	TypeSFixed32 = descriptorpb.FieldDescriptorProto_TYPE_SFIXED32
+	TypeSFixed64 = descriptorpb.FieldDescriptorProto_TYPE_SFIXED64
+	TypeSInt32   = descriptorpb.FieldDescriptorProto_TYPE_SINT32
+	TypeSInt64   = descriptorpb.FieldDescriptorProto_TYPE_SINT64
+	TypeUInt32   = descriptorpb.FieldDescriptorProto_TYPE_UINT32
+
+	// Boolean and string types
+	TypeBool   = descriptorpb.FieldDescriptorProto_TYPE_BOOL
+	TypeString = descriptorpb.FieldDescriptorProto_TYPE_STRING
+	TypeBytes  = descriptorpb.FieldDescriptorProto_TYPE_BYTES
+
+	// Complex types
+	TypeGroup   = descriptorpb.FieldDescriptorProto_TYPE_GROUP
+	TypeMessage = descriptorpb.FieldDescriptorProto_TYPE_MESSAGE
+	TypeEnum    = descriptorpb.FieldDescriptorProto_TYPE_ENUM
+)
+
+// Label type aliases for field cardinality
+const (
+	LabelOptional = descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL
+	LabelRequired = descriptorpb.FieldDescriptorProto_LABEL_REQUIRED
+	LabelRepeated = descriptorpb.FieldDescriptorProto_LABEL_REPEATED
+)

--- a/generator/types_test.go
+++ b/generator/types_test.go
@@ -1,0 +1,41 @@
+package generator
+
+import (
+	"testing"
+
+	"darvaza.org/core"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+// TestTypeConstants verifies that our type aliases match the protobuf constants
+func TestTypeConstants(t *testing.T) {
+	// cspell:ignore SFIXED SINT
+	// Test scalar types
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_DOUBLE, TypeDouble, "TypeDouble")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_FLOAT, TypeFloat, "TypeFloat")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_INT64, TypeInt64, "TypeInt64")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_UINT64, TypeUInt64, "TypeUInt64")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_INT32, TypeInt32, "TypeInt32")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_FIXED64, TypeFixed64, "TypeFixed64")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_FIXED32, TypeFixed32, "TypeFixed32")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_BOOL, TypeBool, "TypeBool")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_STRING, TypeString, "TypeString")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_BYTES, TypeBytes, "TypeBytes")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_UINT32, TypeUInt32, "TypeUInt32")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_SFIXED32, TypeSFixed32, "TypeSFixed32")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_SFIXED64, TypeSFixed64, "TypeSFixed64")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_SINT32, TypeSInt32, "TypeSInt32")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_SINT64, TypeSInt64, "TypeSInt64")
+
+	// Test complex types
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_GROUP, TypeGroup, "TypeGroup")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_MESSAGE, TypeMessage, "TypeMessage")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_TYPE_ENUM, TypeEnum, "TypeEnum")
+}
+
+// TestLabelConstants verifies that our label aliases match the protobuf constants
+func TestLabelConstants(t *testing.T) {
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL, LabelOptional, "LabelOptional")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_LABEL_REQUIRED, LabelRequired, "LabelRequired")
+	core.AssertEqual(t, descriptorpb.FieldDescriptorProto_LABEL_REPEATED, LabelRepeated, "LabelRepeated")
+}

--- a/internal/build/cspell.json
+++ b/internal/build/cspell.json
@@ -10,16 +10,19 @@
     "descriptorpb",
     "Errorf",
     "fieldalignment",
+    "godoc",
     "golangci",
     "GOTEST",
     "GOXTOOLS",
     "languagetool",
     "lazybuffer",
     "nanorpc",
+    "pluginpb",
     "Println",
     "protoc",
     "protomcp",
-    "shellcheck"
+    "shellcheck",
+    "Wrapf"
   ],
   "ignorePaths": [
     "*.lock",

--- a/internal/build/cspell.json
+++ b/internal/build/cspell.json
@@ -7,6 +7,7 @@
     "coverprofile",
     "coverpkg",
     "darvaza",
+    "descriptorpb",
     "Errorf",
     "fieldalignment",
     "golangci",
@@ -16,6 +17,7 @@
     "lazybuffer",
     "nanorpc",
     "Println",
+    "protoc",
     "protomcp",
     "shellcheck"
   ],


### PR DESCRIPTION
# Add generator module for protoc plugin development

## Summary

Introduces a new `generator` submodule providing essential utilities for
developing protocol buffer compiler (protoc) plugins. This module offers
type-safe descriptor handling, comprehensive test utilities, and follows
strict TDD principles with 100% test coverage.

## Motivation

The protomcp.org ecosystem requires robust utilities for working with
protocol buffer descriptors when building code generators. This module
provides the foundational layer that other modules (particularly the
planned `options` module) will depend upon for descriptor traversal,
type checking, and manipulation.

## Changes

### Core Functionality

The module provides three main categories of utilities:

#### 1. Descriptor Type Checking (descriptor.go)

- Type casting functions (`AsFoo`) for safe conversion to specific
  descriptor types with essential field validation.
- Boolean checking functions (`IsFoo`) for type verification.
- Support for all major descriptor types: File, Message, Field, Enum,
  Service, and Method.
- Special `AsMessageWithName`/`IsMessageWithName` for name-based matching.
- Field characteristic helpers for cardinality (repeated, map, oneof)
  and classification (scalar, message, group, enum).
- Map field detection with both heuristic (`AsMapField`) and definitive
  (`AsMapFieldWithMessage`) checking.
- Proto3Optional field semantics documentation.
- Validation of essential fields (Name, Type, etc.) in all AsXType functions.
- Separate handling for Group types (deprecated in proto2, not in proto3).

<!-- cspell:ignore testutils -->

#### 2. Test Utilities (testutils.go, types.go)

- Complete field constructors for creating fully-specified test
  descriptors.
- Minimal field constructors for testing specific properties in
  isolation.
- Helper functions for creating messages, enums, services, and files.
- Type constants for all protobuf field types and labels.

#### 3. Comprehensive Testing

Test files: descriptor_test.go, testutils_test.go, types_test.go

- Table-driven tests following darvaza.org/core patterns.
- Factory pattern for test case generation.
- Edge case coverage for robust validation.
- 100% test coverage achieved and maintained.

### Documentation

- Comprehensive README with usage examples and API reference.
- Package documentation in doc.go.
- Clear organisation of functions into logical categories.
- Tables for better readability of function signatures.

### Implementation Progression

The module was developed incrementally following TDD principles across
three commits:

1. **Placeholder**: Established initial module structure with planned
   architecture.
2. **Test utilities**: Created comprehensive test utilities for descriptor
   creation, including factory functions and type constants.
3. **Core functionality**: Implemented type checking and casting functions
   with 100% test coverage.

## Testing

All functionality has been thoroughly tested:

- **Coverage**: 100% test coverage across all files.
- **Patterns**: Consistent use of table-driven tests.
- **Organisation**: Factory functions for test case generation.
- **Edge cases**: Comprehensive coverage including nil inputs and invalid
  types.

## Impact

This module provides the foundation for:

- Building robust protoc plugins.
- Implementing the options override system.
- Creating type-safe descriptor traversal utilities.
- Standardising test creation across the protomcp.org ecosystem.

## Future Work

The README documents planned features that will be added incrementally:

- Path construction and naming utilities.
- Descriptor traversal functions (Find, ForEach patterns).
- Visitor pattern for walking descriptor trees.
- Context management for build environments.
- Code generation output helpers.

## Breaking Changes

None. This is a new module with no existing consumers.

## Dependencies

Minimal external dependencies:

- `google.golang.org/protobuf` for descriptor types.
- `darvaza.org/core` for test utilities only (not runtime).

## Review Notes

- All functions follow consistent `AsFoo`/`IsFoo` naming patterns.
- Nil safety is guaranteed across all public APIs.
- British English spelling used throughout documentation.
- Line lengths kept under 80 characters for readability.
- Comprehensive documentation at package, function, and example levels.

___

### **PR Type**

Enhancement

___

### **Description**

- Add comprehensive descriptor type checking utilities with AsFoo/IsFoo
  pattern.

- Implement field classification (scalar, message, enum) and cardinality
  helpers (repeated, map, oneof).

- Create extensive test utilities with factory functions and type constants.

- Achieve 100% test coverage with table-driven tests following darvaza.org
  patterns.

- Graduate module from placeholder to active development.

___

### Diagram Walkthrough

```mermaid
flowchart LR
  A["generator module"] --> B["descriptor.go"]
  A --> C["testutils.go"]
  A --> D["types.go"]
  A --> E["doc.go"]
  B --> F["Type checking<br/>AsFoo/IsFoo"]
  B --> G["Field classification<br/>Scalar/Message/Enum"]
  B --> H["Field cardinality<br/>Repeated/Map/OneOf"]
  C --> I["Test constructors<br/>NewField variants"]
  C --> J["Minimal constructors<br/>NewFieldWithType"]
  D --> K["Type constants<br/>TypeString, TypeInt32"]
  D --> L["Label constants<br/>LabelOptional, LabelRepeated"]
```

<!-- markdownlint-disable -->
<!-- cspell:ignore coderabbit -->

<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>descriptor.go</strong><dd><code>Implement descriptor type checking and field classification</code></dd></td>
  <td><a href="https://github.com/protomcp/common/pull/3/files#diff-e47c5102ba35780462b0d73fcf9d5a61dd12a8c2">+356/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>testutils.go</strong><dd><code>Create test utilities for descriptor construction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/protomcp/common/pull/3/files#diff-dc72e9c68f425e94739e504e0915c0cfe3112466">+235/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>types.go</strong><dd><code>Define type and label constants for protobuf fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/protomcp/common/pull/3/files#diff-385f528dd9a7bf836d89c17f8aee54c91ea11797">+41/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>descriptor_test.go</strong><dd><code>Add comprehensive tests with factory pattern</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/protomcp/common/pull/3/files#diff-604787013108692bfad9d9ffabc04a49b74473f4d3124d95769e0cd0962dd942">+425/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>testutils_test.go</strong><dd><code>Test all utility functions and edge cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/protomcp/common/pull/3/files#diff-f29d023679c12f67913a58ff1800553c7c4028f3cdfb54baaa4410f953beaecc">+417/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>types_test.go</strong><dd><code>Test type and label constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/protomcp/common/pull/3/files#diff-types_test">+41/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>doc.go</strong><dd><code>Add package documentation with API reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/protomcp/common/pull/3/files#diff-5b575806537dd8e15943da90f327934c25f46b9d">+52/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AGENT.md</strong><dd><code>Document generator submodule in development guide</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/protomcp/common/pull/3/files#diff-c1e87407ce72f38b645f627c7fbda6e6999170c840cded6ce82c1bd2c10923e8">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong><dd><code>Add generator utilities to main README</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/protomcp/common/pull/3/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>generator/README.md</strong><dd><code>Create comprehensive module documentation with examples</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/protomcp/common/pull/3/files#diff-a715bdcf88cd771d7ae09bd01863bab314ff194ba28e984689e9040d87846db9">+270/-194</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>LICENCE.txt</strong><dd><code>Add MIT licence for generator submodule</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/protomcp/common/pull/3/files#diff-c0f8bd37207bd6cb420debc71fcfa003d8164d2827876ed6e0d233b947c71656">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>go.mod</strong><dd><code>Initialise Go module with dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/protomcp/common/pull/3/files#diff-b827f55ed9eb4afc993ba2d44b448b74dfb6177deb13508ab36515c4c4341938">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cspell.json</strong><dd><code>Add protobuf-related terms to spell checker</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/protomcp/common/pull/3/files#diff-3094120fcb2e87cf154fce1053bc486a13eaa9d4200a24f858bc9c39ec2e0936">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>go.sum</strong><dd><code>Add dependency checksums for module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/protomcp/common/pull/3/files#diff-874492ac35aad47ffa54891f67d2ff868c4470a4112641bfb961ce45ea6bffa2">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Adds a Generator module with descriptor inspection, field classification (repeated, map, oneof, optional/required), type-checking helpers, type alias constants, and builder/test utilities for protoc plugin development.

- **Documentation**
  - Adds comprehensive Generator docs, package-level docs, generator README, and updates main README with a Go Report Card badge and “Generator Utilities” entry plus usage examples.

- **Tests**
  - Adds extensive unit tests covering descriptor predicates, builder utilities, and type/label aliases.

- **Chores**
  - Adds MIT license for Generator, initializes module metadata, and updates internal spelling dictionary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
